### PR TITLE
Added Kube Events

### DIFF
--- a/docs/newsfeeds.md
+++ b/docs/newsfeeds.md
@@ -40,6 +40,7 @@
 * [paper.li: The kubernetes daily](https://paper.li/skippbox/1446802542#/)
 * [feedly.com](https://feedly.com)
 * [==nativecloud.dev== 🌟](https://nativecloud.dev)
+* [Kube Events](https://kube.events)
 
 ## Stack Overflow Collectives
 - [Stack Overflow Collectives 🌟](https://stackoverflow.com/collectives) Communities for your favorite technologies


### PR DESCRIPTION
[Kube Events](https://kube.events) aggregates all webinars, training, conferences and meetups related to Kubernetes.