### PR TITLE
fix: Fabric8 Kubernetes Client is not deprecated

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -37,7 +37,7 @@
     - [OpenShift GitOps (ArgoCD)](#openshift-gitops-argocd)
     - [ArgoCD](#argocd)
     - [GitLab Pipelines on OpenShift](#gitlab-pipelines-on-openshift)
-    - [Deploying Web Applications with Eclipse JKube (formerly known as fabric8)](#deploying-web-applications-with-eclipse-jkube-formerly-known-as-fabric8)
+    - [Deploying Web Applications with Eclipse JKube (formerly known as fabric8)](#deploying-web-applications-with-eclipse-jkube-formerly-known-as-fabric8-maven-plugin)
     - [Monitoring Services with OpenShift ServiceMesh](#monitoring-services-with-openshift-servicemesh)
     - [Red Hat Migration Toolkit for Applications](#red-hat-migration-toolkit-for-applications)
     - [Red Hat Advanced Cluster Management RHACM. Red Hat’s Hybrid And Multi-Cloud Platform](#red-hat-advanced-cluster-management-rhacm-red-hats-hybrid-and-multi-cloud-platform)
@@ -406,7 +406,7 @@
 ### GitLab Pipelines on OpenShift
 - [openshift.com: Building GitLab Pipelines on OpenShift](https://www.openshift.com/blog/building-openshift-pipelines-with-gitlab)
 
-### Deploying Web Applications with Eclipse JKube (formerly known as fabric8)
+### Deploying Web Applications with Eclipse JKube (formerly known as Fabric8 Maven Plugin)
 - [Building and Deploying a Weather Web Application onto Kubernetes/Red Hat OpenShift using Eclipse JKube](https://itnext.io/building-and-deploying-a-weather-web-application-onto-kubernetes-red-hat-openshift-using-eclipse-62bf7c924be4)
 - [Java development on top of Kubernetes using Eclipse JKube](https://developers.redhat.com/blog/2020/08/24/java-development-on-top-of-kubernetes-using-eclipse-jkube/)
   - [medium: Deploy Quarkus Todo List App to Kubernetes Using Eclipse JKube](https://medium.com/swlh/deploy-quarkus-todo-list-app-to-kubernetes-using-eclipse-jkube-c774ef6b68f0)

--- a/docs/kubernetes-client-libraries.md
+++ b/docs/kubernetes-client-libraries.md
@@ -2,9 +2,8 @@
 - [Kubernetes Client Libraries](#kubernetes-client-libraries)
 - [Go Clients for Kubernetes](#go-clients-for-kubernetes)
 - [Python Client for Kubernetes](#python-client-for-kubernetes)
-- [Fabric8 Java Client for Kubernetes (deprecated)](#fabric8-java-client-for-kubernetes-deprecated)
+- [Fabric8 Java Client for Kubernetes](#fabric8-java-client-for-kubernetes)
 - [CDK8s Python](#cdk8s-python)
-- [Eclipse Jkube Java Client for Kubernetes (formerly known as Fabric8). Kubernetes & OpenShift Maven Plugins](#eclipse-jkube-java-client-for-kubernetes-formerly-known-as-fabric8-kubernetes--openshift-maven-plugins)
 - [Java Operator SDK](#java-operator-sdk)
 ## Kubernetes Client Libraries
 - [github.com/kubernetes-client 🌟](https://github.com/kubernetes-client)
@@ -26,27 +25,18 @@
 - [github.com/kubernetes-client/python-base](https://github.com/kubernetes-client/python-base)
 - [==medium.com/@dimitrijevskiv: Monitor Kubernetes pod status from a Jenkins pipeline==](https://medium.com/@dimitrijevskiv/monitor-kubernetes-pod-status-from-a-jenkins-pipeline-e25c744d944d)
 
-## Fabric8 Java Client for Kubernetes (deprecated)
-- [Fabric8](https://fabric8.io/) has been available as a Java client for Kubernetes since 2015, and today is one of the most popular client libraries for Kubernetes (the most popular is [client-go](https://github.com/kubernetes/client-go), which is the client library for the Go programming language on Kubernetes). In recent years, **fabric8 has evolved from a Java client for the Kubernetes REST API to a full-fledged alternative to the kubectl command-line tool for Java-based development**.
+## Fabric8 Java Client for Kubernetes
+- [Fabric8 Kubernetes Client](https://github.com/fabric8io/kubernetes-client) has been available as a Java client for Kubernetes since 2015, and today is one of the most popular client libraries for Kubernetes (the most popular is [client-go](https://github.com/kubernetes/client-go), which is the client library for the Go programming language on Kubernetes). In recent years, **fabric8 has evolved from a Java client for the Kubernetes REST API to a full-fledged alternative to the kubectl command-line tool for Java-based development**.
 - [developers.redhat.com: Getting started with the fabric8 Kubernetes Java client](https://developers.redhat.com/blog/2020/05/20/getting-started-with-the-fabric8-kubernetes-java-client/)
 - [developers.redhat.com: How the fabric8 Maven plug-in deploys Java applications to OpenShift](https://developers.redhat.com/blog/2020/05/28/how-the-fabric8-maven-plug-in-deploys-java-applications-to-openshift/)
 - [Fabric8.io Microservices Development Platform](https://fabric8.io/) It is an open source microservices platform based on Docker, Kubernetes and Jenkins. It is built by the Red Hat guys.The purpose of the project is to make it easy to create microservices, build, test and deploy them via Continuous Delivery pipelines then run and manage them with Continuous Improvement and ChatOps. Fabric8 installs and configures the following things for you automatically: Jenkins, Gogs, Fabric8 registry, Nexus, SonarQube.
 - [developers.redhat.com: What’s new in Fabric8 Kubernetes Java client 4.12.0](https://developers.redhat.com/blog/2020/10/30/whats-new-in-fabric8-kubernetes-java-client-4-12-0/)
+- [blog.marcnuri.com: Fabric8 Kubernetes Client for Java introduction](https://blog.marcnuri.com/kubernetes-client-java-fabric8-introduction) 
 - [blog.marcnuri.com: Build Kubernetes controllers with Fabric8 Kubernetes Client, Quarkus, and JKube](https://blog.marcnuri.com/fabric8-kubernetes-java-client-and-quarkus-and-graalvm) 
 
 ## CDK8s Python
 - [cdk8s](https://github.com/cdk8s-team/cdk8s) Define Kubernetes native apps and abstractions using object-oriented programming
 - [blog.twstewart.me: cdk8s-python - A Love and Hate Experience](https://blog.twstewart.me/posts/cdk8s-python) CDK8S is an alpha level library that allows you to write high level abstractions of Kubernetes objects like deployments, services, and more all in your favorite language ( TypeScript, Python, and others).
-
-## Eclipse Jkube Java Client for Kubernetes (formerly known as Fabric8). Kubernetes & OpenShift Maven Plugins
-- [Eclipse JKube 🌟](https://www.eclipse.org/jkube/) Cloud-Native Java Applications without a hassle. Eclipse JKube is a collection of plugins and libraries that are used for building container images using Docker, JIB or S2I build strategies. Eclipse JKube generates and deploys Kubernetes/OpenShift manifests at compile time too. It brings your Java applications on to Kubernetes and OpenShift by leveraging the tasks required to make your application cloud-native. Eclipse JKube also provides a set of tools such as watch, debug, log, etc. to improve your developer experience.
-- [Github: Eclipse Jkube](https://github.com/eclipse/jkube)
-- [developers.redhat.com: Migrating from Fabric8 Maven Plugin to Eclipse JKube 1.0.0](https://developers.redhat.com/blog/2020/09/21/migrating-from-fabric8-maven-plugin-to-eclipse-jkube-1-0-0/)
-- [developers.redhat.com: Cloud-native Java applications made easy: Eclipse JKube 1.0.0 now available](https://developers.redhat.com/blog/2020/09/09/cloud-native-java-applications-made-easy-eclipse-jkube-1-0-0-now-available/)
-- [developers.redhat.com: Java development on top of Kubernetes using Eclipse JKube](https://developers.redhat.com/blog/2020/08/24/java-development-on-top-of-kubernetes-using-eclipse-jkube/)
-- [eclipse.org: Migration Guide for projects using Fabric8 Maven Plugin to Eclipse JKube 🌟](https://www.eclipse.org/jkube/docs/migration-guide/)
-- [youtube: Deploying a Quarkus application into Kubernetes using JKube | Cloud Tool Time | Marc Nuri 🌟](https://www.youtube.com/watch?v=HDDfdZqwM1E&ab_channel=EclipseFoundation)
-- [blog.marcnuri.com: Eclipse JKube 1.4.0 is now available!](https://blog.marcnuri.com/eclipse-jkube-1-4-0)
 
 ## Java Operator SDK
 - [javaoperatorsdk.io: Build Kubernetes Operators in Java without hassle](https://javaoperatorsdk.io/) Whether you want to build applications that operate themselves or provision infrastructure from Java code, Kubernetes Operators are the way to go. This SDK will make it easy for Java developers to embrace this new way of automation. The java-operator-sdk is based on the fabric8 Kubernetes client.

--- a/docs/maven-gradle.md
+++ b/docs/maven-gradle.md
@@ -10,7 +10,8 @@
 	- [Maven Cheat Sheets](#maven-cheat-sheets)
 	- [Other Commands](#other-commands)
 	- [Docker Maven Plugin (fabric8)](#docker-maven-plugin-fabric8)
-	- [Fabric8 Maven Plugin](#fabric8-maven-plugin)
+	- [Fabric8 Maven Plugin](#fabric8-maven-plugin-deprecated)
+	- [Eclipse JKube (formerly known as Fabric8 Maven Plugin) - Kubernetes & OpenShift Maven and Gradle Plugins](#eclipse-jkube-formerly-known-as-fabric8-maven-plugin---kubernetes--openshift-maven-and-gradle-plugins)
 - [Gradle](#gradle)
 	- [Gradle Cheat Sheets](#gradle-cheat-sheets)
 - [SDKMAN](#sdkman)
@@ -100,8 +101,19 @@ jar tf target/example-1.0.0-SNAPSHOT.jar
 ### Docker Maven Plugin (fabric8)
 - [docker-maven-plugin](https://github.com/fabric8io/docker-maven-plugin) This is a Maven plugin for building Docker images and managing containers for integration tests. It works with Maven 3.0.5 and Docker 1.6.0 or later.
 
-### Fabric8 Maven Plugin
+### Fabric8 Maven Plugin (deprecated)
 - [developers.redhat.com: How the fabric8 Maven plug-in deploys Java applications to OpenShift](https://developers.redhat.com/blog/2020/06/02/how-the-fabric8-maven-plug-in-deploys-java-applications-to-openshift/)
+
+## Eclipse JKube (formerly known as Fabric8 Maven Plugin) - Kubernetes & OpenShift Maven and Gradle Plugins
+- [Eclipse JKube 🌟](https://www.eclipse.org/jkube/) Cloud-Native Java Applications without a hassle. Eclipse JKube is a collection of plugins and libraries that are used for building container images using Docker, JIB or S2I build strategies. Eclipse JKube generates and deploys Kubernetes/OpenShift manifests at compile time too. It brings your Java applications on to Kubernetes and OpenShift by leveraging the tasks required to make your application cloud-native. Eclipse JKube also provides a set of tools such as watch, debug, log, etc. to improve your developer experience.
+- [GitHub: Eclipse JKube](https://github.com/eclipse/jkube)
+- [developers.redhat.com: Migrating from Fabric8 Maven Plugin to Eclipse JKube 1.0.0](https://developers.redhat.com/blog/2020/09/21/migrating-from-fabric8-maven-plugin-to-eclipse-jkube-1-0-0/)
+- [developers.redhat.com: Cloud-native Java applications made easy: Eclipse JKube 1.0.0 now available](https://developers.redhat.com/blog/2020/09/09/cloud-native-java-applications-made-easy-eclipse-jkube-1-0-0-now-available/)
+- [developers.redhat.com: Java development on top of Kubernetes using Eclipse JKube](https://developers.redhat.com/blog/2020/08/24/java-development-on-top-of-kubernetes-using-eclipse-jkube/)
+- [eclipse.org: Migration Guide for projects using Fabric8 Maven Plugin to Eclipse JKube 🌟](https://www.eclipse.org/jkube/docs/migration-guide/)
+- [YouTube: Deploying a Quarkus application into Kubernetes using JKube | Cloud Tool Time | Marc Nuri 🌟](https://www.youtube.com/watch?v=HDDfdZqwM1E&ab_channel=EclipseFoundation)
+- [blog.marcnuri.com: Eclipse JKube introduction: Java tools and plugins for Kubernetes and OpenShift](https://blog.marcnuri.com/eclipse-jkube-introduction-kubernetes-openshift)
+- [blog.marcnuri.com: Eclipse JKube 1.4.0 is now available!](https://blog.marcnuri.com/eclipse-jkube-1-4-0)
 
 ## Gradle
 - [gradle.org](https://gradle.org/)

--- a/docs/openshift-pipelines.md
+++ b/docs/openshift-pipelines.md
@@ -14,7 +14,7 @@
 - [All about OpenShift Pipelines](#all-about-openshift-pipelines)
 	- [Jenkins CICD Getting started with Groovy and Docker Containers](#jenkins-cicd-getting-started-with-groovy-and-docker-containers)
 	- [Fabric8 Pipeline Library (deprecated)](#fabric8-pipeline-library-deprecated)
-	- [Eclipse Jkube Pipeline Library (formerly known as Fabric8). Kubernetes & OpenShift Maven Plugins](#eclipse-jkube-pipeline-library-formerly-known-as-fabric8-kubernetes--openshift-maven-plugins)
+	- [Eclipse JKube Pipeline Library (formerly known as Fabric8 Kubernetes Plugin). Kubernetes & OpenShift Plugins](#eclipse-jkube-pipeline-library-formerly-known-as-fabric8-kubernetes-plugin-kubernetes--openshift-plugins)
 	- [Jenkins Pipelines with OpenShift 3](#jenkins-pipelines-with-openshift-3)
 	- [OpenShift Jenkins Pipeline (DSL) Plugin. Scripted Syntax (Groovy DSL syntax) VS Declarative Syntax](#openshift-jenkins-pipeline-dsl-plugin-scripted-syntax-groovy-dsl-syntax-vs-declarative-syntax)
 		- [Red Hat Communities of Practice](#red-hat-communities-of-practice)
@@ -89,9 +89,9 @@
 * [medium - fabric8, please check out jenkins X instead](https://medium.com/@jstrachan/fabric8-please-check-out-jenkins-x-instead-8295a025173a)
 * [github - fabric8, maven plugin](https://github.com/fabric8io/fabric8-maven-plugin )
 
-### Eclipse Jkube Pipeline Library (formerly known as Fabric8). Kubernetes & OpenShift Maven Plugins
-* [Eclipse JKube 🌟](https://www.eclipse.org/jkube/) Cloud-Native Java Applications without a hassle. Eclipse JKube is a collection of plugins and libraries that are used for building container images using Docker, JIB or S2I build strategies. Eclipse JKube generates and deploys Kubernetes/OpenShift manifests at compile time too. It brings your Java applications on to Kubernetes and OpenShift by leveraging the tasks required to make your application cloud-native. Eclipse JKube also provides a set of tools such as watch, debug, log, etc. to improve your developer experience.
-* [Github: Eclipse Jkube](https://github.com/eclipse/jkube)
+### Eclipse JKube Pipeline Library (formerly known as Fabric8 Kubernetes Plugin). Kubernetes & OpenShift Plugins
+* [Eclipse JKube 🌟](https://www.eclipse.org/jkube/) Cloud-Native Java Applications without a hassle. Eclipse JKube is a collection of Maven and Gradle plugins, and libraries that are used for building container images using Docker, JIB or S2I build strategies. Eclipse JKube generates and deploys Kubernetes/OpenShift manifests at compile time too. It brings your Java applications on to Kubernetes and OpenShift by leveraging the tasks required to make your application cloud-native. Eclipse JKube also provides a set of tools such as watch, debug, log, etc. to improve your developer experience.
+* [GitHub: Eclipse JKube](https://github.com/eclipse/jkube)
 
 ### Jenkins Pipelines with OpenShift 3
 * [slideshare.net: CI/CD with Openshift and Jenkins 🌟](https://www.slideshare.net/arilivigni/cicd-with-openshift-and-jenkins)


### PR DESCRIPTION
Fabric8 Kubernetes Client is still alive and kicking!
Version 6.0.0 GA to be released on early July with many
ground-breaking and game changer features.

Eclipse JKube is the successor of Fabric8 Maven Plugin (FMP),
which is deprecated. JKube includes Maven Plugins for
the deployment of Java Applications into K8s, just as FMP.
And also equivalent Gradle plugins (which are new).