### PR TITLE
Pointing to the report page instead of the report PDF

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ A curated list of awesome references collected since 2018. Microservices archite
 - [10 Cloud Deficiencies You Should Know](https://thenewstack.io/10-cloud-deficiencies-you-should-know/)
 - [==How to Explain Kubernetes to a Business Team==](https://dzone.com/articles/how-to-explain-kubernetes-to-a-business-team)
 - [==Pets vs. Cattle: The Future of Kubernetes in 2022==](https://traefik.io/blog/pets-vs-cattle-the-future-of-kubernetes-in-2022)
-- [dok.community: Data on Kubernetes 2021 🌟](https://dok.community/wp-content/uploads/2021/10/DoK_Report_2021.pdf) 
+- [dok.community: Data on Kubernetes 2021 🌟](https://dok.community/dokc-2021-report/) 
 - [A Kubernetes Documentary Shares Google’s Open Source Story](https://thenewstack.io/a-kubernetes-documentary-shares-googles-open-source-story/)
 - [==Infrastructure as Code in DevOps==](https://alpacked.io/blog/infrastructure-as-code-for-devops/) 
 - [Kubernetes at Scale without GitOps Is a Bad Idea](https://thenewstack.io/kubernetes-at-scale-without-gitops-is-a-bad-idea/)

--- a/docs/kubernetes-storage.md
+++ b/docs/kubernetes-storage.md
@@ -75,7 +75,7 @@
 - [==DoK Community== 🌟](https://dok.community) 
 - Kubernetes was originally designed to run stateless workloads. Today, it is increasingly used to run databases and other stateful workloads. Yet despite the success of these early adopters, there remain few known good practices for running data on Kubernetes.
 - After discussions with thousands of companies and individuals running data workloads on Kubernetes we’ve come to see that there is a need for a sharing of patterns and concerns about how to build and operate data-centric applications on Kubernetes. As a result, the **Data on Kubernetes Community (DoKC)** was born.
-- [==dok.community: Data on Kubernetes 2021== 🌟](https://dok.community/wp-content/uploads/2021/10/DoK_Report_2021.pdf) Insights from over 500 executives and technology leaders on how Kubernetes is being used for data and the factors driving further adoption
+- [==dok.community: Data on Kubernetes 2021== 🌟](https://dok.community/dokc-2021-report/) Insights from over 500 executives and technology leaders on how Kubernetes is being used for data and the factors driving further adoption
 
 ## Kubernetes Volumes Guide
 - [matthewpalmer.net: Filesystem vs Volume vs Persistent Volume 🌟](https://matthewpalmer.net/kubernetes-app-developer/articles/kubernetes-volumes-example-nfs-persistent-volume.html) This is a guide that covers:


### PR DESCRIPTION
I am the head of content at the DoKC. As a community, we need to track how our content performs and who reads it to better understand the impact of our work and ensure it is useful to our community. Pointing to the PDF directly means that we don't get to know the data we need.