### PR TITLE
Update CRC home

### DIFF
--- a/docs/ocp4.md
+++ b/docs/ocp4.md
@@ -565,7 +565,7 @@ OpenShift 4.1|5.6.16|?|5.6.16|No
 ### Local Development Environment
 
 - For version 3 we have [Container Development Kit](https://developers.redhat.com/products/cdk/overview) (or its open source equivalent for OKD - [minishift](https://github.com/minishift/minishift/releases)) which launches a single node VM with Openshift and it does it in a few minutes. It’s perfect for testing also as a part of CI/CD pipeline.
-- Openshift 4 on your laptop: There is a working solution for single node OpenShift cluster. It is provided by a new project called [CodeReady Containers](https://github.com/code-ready/crc/).
+- Openshift 4 on your laptop: There is a working solution for single node OpenShift cluster. It is provided by a new project called [CodeReady Containers](https://github.com/crc-org/crc/).
 - [Procedure:](https://developers.redhat.com/blog/2019/09/05/red-hat-openshift-4-on-your-laptop-introducing-red-hat-codeready-containers/)
 
 ```bash
@@ -673,8 +673,9 @@ oc login
 
 ## Red Hat CodeReady Containers. OpenShift 4 on your laptop
 
+- [Homepage](https://crc.dev)
 - [developers.redhat.com: Developing applications on Kubernetes 🌟](https://developers.redhat.com/topics/kubernetes/)
-- [code-ready.github.io/crc: Getting Strated Guide 🌟](https://code-ready.github.io/crc/)
+- [crc-org/crc: Getting Started Guide 🌟](https://crc-org.github.io/crc/) 
 - [Red Hat OpenShift 4.2 on your laptop: Introducing **Red Hat CodeReady Containers**](https://developers.redhat.com/blog/2019/09/05/red-hat-openshift-4-on-your-laptop-introducing-red-hat-codeready-containers/)
 - [dzone: Code Ready Containers - Decision Management Developer Tools Update](https://dzone.com/articles/code-ready-containers-decision-management-develope)
 - [Overview: running crc on a remote server](https://gist.github.com/tmckayus/8e843f90c44ac841d0673434c7de0c6a)


### PR DESCRIPTION
We have moved to a new organization on Github, https://github.com/crc-org, and therefore anything referencing code-ready is out of date.