### PR TITLE
Added a storageclass.info link

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -874,6 +874,7 @@
 #### Kubernetes Volumes
 
 - [Kubernetes Storage - Volumes](kubernetes-storage.md#kubernetes-volumes)
+- [Searchable list of Kubernetes Storage Providers](https://storageclass.info/csidrivers/)
 
 #### Kubernetes Namespaces and Multi Tenancy. Self Service Namespaces
 


### PR DESCRIPTION
storageclass.info provides an extensive searchable list of available Kubernetes CSI drivers (persistent volume providers). The repo is available at: https://github.com/storageclass/storageclass.github.io