### PR TITLE
Add KubeStellar Console to K8s Tools section

### DIFF
--- a/docs/kubernetes-tools.md
+++ b/docs/kubernetes-tools.md
@@ -151,6 +151,7 @@
 - [==kubectx + kubens: : Power tools for kubectl==🌟🌟](https://github.com/ahmetb/kubectx) Faster way to switch between clusters and namespaces in kubectl
 - [go-kubectx](https://github.com/aca/go-kubectx) 5x-10x faster alternative to kubectx. Uses client-go.
 - [kubevious: application centric Kubernetes UI 🌟](https://kubevious.io/) is open-source software that provides a usable and highly graphical interface for Kubernetes. Kubevious renders all configurations relevant to the application in one place.
+- [KubeStellar Console 🌟](https://console.kubestellar.io) Open source AI-powered multi-cluster Kubernetes dashboard with real-time observability, AI-guided operations, and 20+ CNCF integrations. CNCF Sandbox project.
     - [Kubevious SaaS: portal.kubevious.io](https://portal.kubevious.io/)
     - [Kubevious SaaS Beta is Live!](https://kubevious.io/blog/post/kubevious-saas-beta-launch)
     - [==kubevious.io: Built-in Validators==](https://kubevious.io/docs/built-in-validators/) Kubevious comes with 32 build-in validators to detect misconfigurations and violations to Kubernetes and Cloud-Native best practices.


### PR DESCRIPTION
## Summary

Adds [KubeStellar Console](https://console.kubestellar.io) to the K8s Tools section in `docs/kubernetes-tools.md`, alongside other Kubernetes UI/dashboard tools like kubevious, Kubecle, and VMware Octant.

**What it is:**
- Open source AI-powered multi-cluster Kubernetes dashboard
- Real-time observability with AI-guided operations
- 20+ CNCF integrations (Argo CD, Prometheus, Grafana, Kyverno, OpenTelemetry, and more)
- CNCF Sandbox project
- GitHub: https://github.com/kubestellar/console

## Placement

Added in the K8s Tools section near other multi-cluster and dashboard tools (kubevious area), which is the most relevant location given KubeStellar Console is a web UI for managing and observing multiple Kubernetes clusters.