### PR TITLE
Add KubeStellar Console to AI Agents & MCP section

### DIFF
--- a/docs/ai-agents-mcp.md
+++ b/docs/ai-agents-mcp.md
@@ -1,0 +1,21 @@
+# AI Agents and Model Context Protocol (MCP) for Kubernetes
+
+Resources, tools, and projects related to autonomous AI agents, Model Context Protocol (MCP) implementations, and LLM orchestration within Kubernetes environments.
+
+1. [Introduction](#introduction)
+2. [AI Agents](#ai-agents)
+3. [Model Context Protocol (MCP)](#model-context-protocol-mcp)
+4. [LLM Operators and Infrastructure](#llm-operators-and-infrastructure)
+
+## Introduction
+
+- [anthropic.com: Introducing the Model Context Protocol](https://www.anthropic.com/news/model-context-protocol)
+- [modelcontextprotocol.io: MCP Official Documentation](https://modelcontextprotocol.io/introduction)
+
+## AI Agents
+
+## Model Context Protocol (MCP)
+
+- [kubestellar/console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes MCP server (kc-agent) for AI-assisted operations across edge and cloud clusters. 50+ tools for workload placement, policy enforcement, and observability. CNCF Sandbox project.
+
+## LLM Operators and Infrastructure


### PR DESCRIPTION
Adds **KubeStellar Console** to the Model Context Protocol (MCP) section in the AI Agents & MCP page.

KubeStellar Console includes kc-agent, a built-in MCP server with 50+ tools for multi-cluster Kubernetes AI-assisted operations across edge and cloud clusters.

- CNCF Sandbox project (KubeStellar)
- Repository: https://github.com/kubestellar/console
- Live demo: https://console.kubestellar.io