### PR TITLE
chore: optimize automated workflows and bump to 2.1.5

### DIFF
--- a/.github/workflows/03.1.agentic_v2_metadata.yml
+++ b/.github/workflows/03.1.agentic_v2_metadata.yml
@@ -57,14 +57,17 @@ jobs:
           PYTHONUNBUFFERED: "1"
         run: python -u -m src.v2_metadata
 
-      - name: Create Pull Request for Metadata Update
-        uses: peter-evans/create-pull-request@v8
-        with:
-          branch: bot/v2-metadata-sync
-          base: develop
-          title: "V2 Data: GitHub Metadata Sync"
-          commit-message: "chore: update inventory stars and licenses [skip ci]"
-          labels: "v2-data, metadata-sync"
+      - name: Commit and Push Metadata Updates
+        run: |
+          git config --global user.name "Nubenetes Bot"
+          git config --global user.email "bot@nubenetes.com"
+          git add data/inventory.yaml
+          if git diff --staged --quiet; then
+            echo "No changes in inventory.yaml to commit."
+          else
+            git commit -m "chore: update inventory stars and licenses [skip ci]"
+            git push origin develop
+          fi
 
       - name: Persist Incremental Inventory to Cache
         if: always()

--- a/.github/workflows/03.2.agentic_v2_ai.yml
+++ b/.github/workflows/03.2.agentic_v2_ai.yml
@@ -59,14 +59,17 @@ jobs:
           PYTHONUNBUFFERED: "1"
         run: python -u -m src.v2_ai
 
-      - name: Create Pull Request for Inventory Update
-        uses: peter-evans/create-pull-request@v8
-        with:
-          branch: bot/v2-ai-sync
-          base: develop
-          title: "V2 Data: AI Curator Sync"
-          commit-message: "chore: update inventory AI analysis [skip ci]"
-          labels: "v2-data, ai-curator"
+      - name: Commit and Push AI Analysis Updates
+        run: |
+          git config --global user.name "Nubenetes Bot"
+          git config --global user.email "bot@nubenetes.com"
+          git add data/inventory.yaml
+          if git diff --staged --quiet; then
+            echo "No changes in AI analysis to commit."
+          else
+            git commit -m "chore: update inventory AI analysis [skip ci]"
+            git push origin develop
+          fi
 
       - name: Persist Incremental Inventory to Cache
         if: always()

--- a/.github/workflows/03.3.agentic_v2_videos.yml
+++ b/.github/workflows/03.3.agentic_v2_videos.yml
@@ -72,19 +72,17 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:.
           python src/v2_video_portal.py
 
-      - name: Create Pull Request for Video Hub Update
-        uses: peter-evans/create-pull-request@v8
-        with:
-          branch: bot/v2-video-sync
-          base: develop
-          title: "V2 Content: Video Hub Enrichment Sync"
-          commit-message: "docs: update Video Hub with high-fidelity metadata [skip ci]"
-          labels: "v2-content, video-hub"
-          body: |
-            Automated update of the V2 Video Hub.
-            - Robust metadata extraction (yt-dlp + transcripts)
-            - AI-synthesized technical summaries
-            - Format-compliant Markdown rendering
+      - name: Commit and Push Video Hub Updates
+        run: |
+          git config --global user.name "Nubenetes Bot"
+          git config --global user.email "bot@nubenetes.com"
+          git add data/inventory.yaml v2-docs/videos.md
+          if git diff --staged --quiet; then
+            echo "No automated changes to commit."
+          else
+            git commit -m "docs: update Video Hub with high-fidelity metadata [skip ci]"
+            git push origin develop
+          fi
 
       - name: Persist Incremental Inventory Cache
         if: always()

--- a/.github/workflows/04.1.agentic_v2_publish.yml
+++ b/.github/workflows/04.1.agentic_v2_publish.yml
@@ -82,39 +82,28 @@ jobs:
           python -m src.readme_updater
           python -m src.safety_readme
 
-      - name: Create Pull Request for V2 Elite Update
-        id: cpr
-        uses: peter-evans/create-pull-request@v8
+      - name: Commit and Push V2 Elite Updates
+        run: |
+          git config --global user.name "Nubenetes Bot"
+          git config --global user.email "bot@nubenetes.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No automated changes to commit."
+          else
+            git commit -m "feat: sync V2 elite curated edition and README metrics [skip ci]"
+            git push origin develop
+          fi
+
+      - name: Upload Architecture and Decision Logs
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          branch: bot/v2-elite-sync
-          base: develop
-          title: "V2 Elite: Agentic Optimization Sync (2026)"
-          body-path: pr_description.md
-          commit-message: "feat: sync V2 elite curated edition and README metrics [skip ci]"
-          labels: "v2-elite, agentic-sync"
-
-      - name: Post Supplementary Architecture Audit (Comment)
-        if: steps.cpr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: |
-          if [ -f v2_file_audit.md ]; then
-            gh pr comment $PR_NUMBER --body-file v2_file_audit.md
-          fi
-
-      - name: Post Elite Decision Matrix (Comment)
-        if: steps.cpr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: |
-          if [ -f v2_decision_matrix.md ]; then
-            split -b 60000 v2_decision_matrix.md matrix_part_
-            for part in matrix_part_*; do
-              gh pr comment $PR_NUMBER --body-file $part
-            done
-          fi
+          name: v2-agentic-logs
+          path: |
+            v2_file_audit.md
+            v2_decision_matrix.md
+            v2_safety_report.md
+          if-no-files-found: ignore
 
       - name: Persist Incremental Inventory to Cache
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.1.5]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.1.5) - 2026-05-25
+
+### Changed
+- **Automated Workflow Optimization**: Refactored V2 ecosystem workflows (Metadata, AI Curator, Video Hub, and Publisher) to utilize direct git push to the `develop` branch instead of creating redundant Pull Requests. This eliminates manual overhead and confusion while ensuring derived content is seamlessly synchronized using `[skip ci]` flags.
+- **Workflow Observability**: Integrated GitHub Artifacts for automated architecture audits and decision matrices, replacing redundant PR comments.
+
 ## [[2.1.4]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.1.4) - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Additionally, as of May 2026, Nubenetes has reached the **Platinum Operational T
 | :--- | :--- |
 | **Total Technical Resources (Links)** | **17992+** |
 | **Specialized MD Pages** | **161** |
-| **Total Commits** | **5455+** |
+| **Total Commits** | **5459+** |
 | **Primary AI Engine** | **Google Gemini (Agentic)** |
 <!-- HEART_STATS_END -->
 
@@ -178,7 +178,7 @@ The growth of Nubenetes reflects the acceleration of the Cloud Native ecosystem.
 | 6 | 2023 | 30 | 123 | Maintenance & Refinement |
 | 7 | 2024 | 53 | 218 | Curation Strategy Pivot |
 | 8 | 2025 | 5 | 20 | Stability & Research Phase |
-| 9 | 2026 | 1896 | 7,830 | **Agentic AI Surge** (May 2026 Inception) |
+| 9 | 2026 | 1900 | 7,847 | **Agentic AI Surge** (May 2026 Inception) |
 <!-- ANNUAL_GROWTH_END -->
 
 <!-- ANNUAL_CHART_START -->
@@ -194,8 +194,8 @@ xychart-beta
     title "Nubenetes Annual Growth Metrics (2018–2026)"
     x-axis ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025", "2026"]
     y-axis "Volume (Commits / Estimated New Refs)" 0 --> 9000
-    bar [1445, 586, 8449, 2193, 1660, 123, 218, 20, 7830]
-    bar [350, 142, 2046, 531, 402, 30, 53, 5, 1896]
+    bar [1445, 586, 8449, 2193, 1660, 123, 218, 20, 7847]
+    bar [350, 142, 2046, 531, 402, 30, 53, 5, 1900]
 ```
 <!-- ANNUAL_CHART_END -->
 
@@ -204,7 +204,7 @@ xychart-beta
 | Month | Commits | Est. New Refs | Status |
 | :--- | :---: | :---: | :--- |
 | 2026-04 | 25 | 103 | Active Curation |
-| 2026-05 | 1871 | 7,727 | **Agentic Inception (Gemini Era)** |
+| 2026-05 | 1875 | 7,743 | **Agentic Inception (Gemini Era)** |
 <!-- MONTHLY_SURGE_END -->
 
 ### 2.4. Content Distribution and Semantic Clustering


### PR DESCRIPTION
This PR refactors the automated V2 ecosystem workflows (03.1, 03.2, 03.3, 04.1) to push changes directly to the develop branch using [skip ci], eliminating the creation of redundant and confusing Pull Requests for derived content and metadata.