### PR TITLE
feat: V2 root deployment and version 2.2.1

### DIFF
--- a/.github/workflows/06.1.main.yml
+++ b/.github/workflows/06.1.main.yml
@@ -35,13 +35,13 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      # 1. Build V1 (Root)
-      - name: Build V1 Edition
-        run: mkdocs build -f mkdocs.yml -d site/
-
-      # 2. Build V2 (Subdirectory)
+      # 1. Build V2 (Root)
       - name: Build V2 Elite Edition
-        run: mkdocs build -f v2-mkdocs.yml -d site/v2/
+        run: mkdocs build -f v2-mkdocs.yml -d site/
+
+      # 2. Build V1 (Subdirectory)
+      - name: Build V1 Edition
+        run: mkdocs build -f mkdocs.yml -d site/v1/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.2.1]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.2.1) - 2026-05-25
+
+### Changed
+- **Default Landing Page (V2 at Root)**: Promoted the Nubenetes Elite Portal (V2) to the root of the domain (`https://nubenetes.com/`) to provide a modern, AI-curated default experience.
+- **V1 Archive Relocation**: Moved the exhaustive V1 archive to the `/v1/` subdirectory (`https://nubenetes.com/v1/`).
+- **Navigation Synchronization**: Updated all navigation links and announce banners across both versions to ensure seamless switching between the Elite Portal and the Exhaustive Archive.
+- **Workflow Realignment**: Reconfigured the GitHub Pages deployment pipeline to support the new directory structure while maintaining zero-downtime synchronization.
+
 ## [[2.2.0]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.2.0) - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Nubenetes operates with two distinct editions to serve different engineering nee
 - **Semantic Cross-Linking:** The portal autonomously identifies and links related categories within the same strategic dimension (e.g., suggesting `Flux` when reading about `Argo`), creating a cohesive **Industrial Knowledge Graph**.
 - **Executive Context**: Every strategic dimension features an AI-generated **State-of-the-Art Introduction** providing high-level architectural context and industry direction before the link listings.
 - **Source of Truth:** The `v2-docs/` directory (Derived from V1).
-- **Deployment:** [nubenetes.com/v2/](https://nubenetes.com/v2/)
+- **Deployment:** [nubenetes.com/](https://nubenetes.com/)
 
 ### 5.3. Architecture Comparison Matrix: V1 vs. V2
 To better understand the dual-nature of the project, the following matrix details the technical and philosophical differences between the two editions:

--- a/README.md
+++ b/README.md
@@ -342,10 +342,11 @@ Nubenetes operates with two distinct editions to serve different engineering nee
 - **Purpose:** Preservation of all technical knowledge since 2018.
 - **Scope:** 17,000+ links across 160+ pages.
 - **Source of Truth:** The `docs/` directory.
-- **Deployment:** [nubenetes.com](https://nubenetes.com)
+- **Deployment:** [nubenetes.com/v1/](https://nubenetes.com/v1/)
 
 ### 5.2. V2: The Agentic Elite Edition
 - **Purpose:** A high-density, enterprise-grade portal for the modern Cloud Native ecosystem (2026 and beyond).
+- **Default Experience:** Deployed as the primary landing page at the domain root.
 - **Algorithm:** Uses the **Incremental Elite Engine** to select and classify top-tier resources.
 - **Aesthetic:** "Cyber Cloud" styling (pure black backgrounds, neon cyan accents, advanced glassmorphism).
 - **Visual Standards (Elite Hierarchy):**
@@ -903,10 +904,10 @@ graph LR
     B --> D["V2 Vision Engine"]
     B --> Z["README Sync"]
     D --> E["V2 Update (develop)"]
-    E --> M["Sync to 'master'"]
-    M --> C["Pip Cache & CI/CD Build"]
+    M["Sync to 'master'"] --> C["Pip Cache & CI/CD Build"]
     C --> F["Upload Pages Artifact"]
-    F --> G["Native Deploy to nubenetes.com"]
+    F --> G["Native Deploy to nubenetes.com (V2) and /v1/ (Archive)"]
+    Z --> B
     Z --> B
 ```
 

--- a/docs/images/itopstalk_logo.jpg
+++ b/docs/images/itopstalk_logo.jpg
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang=en>
+  <meta charset=utf-8>
+  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
+  <title>Error 400 (Bad Request)!!1</title>
+  <style>
+    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
+  </style>
+  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
+  <p><b>400.</b> <ins>That’s an error.</ins>
+  <p>Your client has issued a malformed or illegal request.  <ins>That’s all we know.</ins>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Nubenetes: Awesome Kubernetes & Cloud [![Awesome](https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
 !!! tip "Nubenetes V2: Agentic Elite Edition is now live!"
-    Looking for a high-density, AI-curated experience? Explore our [**V2 Elite Portal**](/v2) - Optimized for 2026 Architectural Standards.
+    Looking for a high-density, AI-curated experience? Explore our [**V2 Elite Portal**](/) - Optimized for 2026 Architectural Standards.
 
 A curated list of awesome references collected since 2018. Microservices architectures rely on DevOps practices, automation, CI/CD (Continuous Integration & Delivery), and API-focused designs.
 

--- a/mkdocs-v1-archive.yml
+++ b/mkdocs-v1-archive.yml
@@ -1,5 +1,5 @@
 site_name: Nubenetes
-site_url: https://nubenetes.com
+site_url: https://nubenetes.com/v1/
 site_description: A curated list of awesome IT projects and resources. Inspired by the awesome list.
 site_author: nubenetes@gmail.com
 docs_dir: docs/
@@ -13,7 +13,7 @@ theme:
   icon:
     logo: logo
     repo: fontawesome/brands/github
-  favicon: images/favicon-car-modern.png
+  favicon: images/favicon-ultra.png
   palette:
     - scheme: default
       primary: indigo
@@ -85,6 +85,7 @@ markdown_extensions:
   - abbr
   - def_list
 nav:
+  - "🚀 Try Nubenetes V2 (Elite Portal)": https://nubenetes.com/
   - Home: index.md
   - Intro:
     - Microservice Architecture. From Java EE To Cloud Native. Openshift VS Kubernetes: introduction.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Nubenetes
-site_url: https://nubenetes.com
+site_url: https://nubenetes.com/v1/
 site_description: A curated list of awesome IT projects and resources. Inspired by the awesome list.
 site_author: "Nubenetes"
 docs_dir: docs/
@@ -99,7 +99,7 @@ markdown_extensions:
   - abbr
   - def_list
 nav:
-  - "🚀 Try Nubenetes V2 (Elite)": https://nubenetes.com/v2/
+  - "🚀 Try Nubenetes V2 (Elite Portal)": https://nubenetes.com/
   - Home: index.md
   - Intro:
     - Microservice Architecture. From Java EE To Cloud Native. Openshift VS Kubernetes: introduction.md
@@ -294,7 +294,7 @@ nav:
 copyright: 2026 <a href="https://twitter.com/nubenetes">Nubenetes</a>, <a href="https://nubenetes.com/about/">about</a>.
 extra:
   announce: >-
-    <b>🚀 New!</b> Discover the <a href="https://nubenetes.com/v2/"><b>V2 Elite Portal</b></a> featuring the most premium resources and a renewed design.
+    <b>🚀 New!</b> Discover the <a href="https://nubenetes.com/"><b>V2 Elite Portal</b></a> featuring the most premium resources and a renewed design.
   analytics:
     provider: google
     property: !ENV GOOGLE_ANALYTICS_KEY

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: "Nubenetes V2 | The AI's Cut"
-site_url: "https://nubenetes.com/v2/"
+site_url: "https://nubenetes.com/"
 site_description: "Enterprise-grade curated portal for the modern Cloud Native ecosystem. High-density, AI-driven selection of top-tier resources."
 site_author: "Nubenetes"
 copyright: "Copyright &copy; 2026 Nubenetes Agentic Intelligence"
@@ -94,7 +94,7 @@ markdown_extensions:
   - pymdownx.mark
 
 nav:
-  - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/
+  - "🔙 Back to V1 (Exhaustive Archive)": https://nubenetes.com/v1/
   - "The 2026 Vision": index.md
   - "Agentic Video Hub": videos.md
   - "AI":


### PR DESCRIPTION
This PR promotes the Nubenetes Elite Portal (V2) to the root of the domain and moves the exhaustive V1 archive to a /v1/ subdirectory. All navigation links and deployment workflows have been synchronized.