### PR TITLE
fix: V1 navigation loop and bump to 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.3.3]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.3.3) - 2026-05-25
+
+### Fixed
+- **Navigation Loop**: Corrected the "Back to V1" link to point specifically to `https://nubenetes.com/v1/`. This avoids the automatic redirect at the domain root, allowing users to actually reach the exhaustive archive.
+
 ## [[2.3.2]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.3.2) - 2026-05-25
 
 ### Changed

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -867,7 +867,7 @@ class V2VisionEngine:
             with open("v2-mkdocs.yml", "r") as f: content = f.read()
             nav = [
                 "nav:", 
-                "  - \"🔙 Back to V1 (Exhaustive)\": https://nubenetes.com/", 
+                "  - \"🔙 Back to V1 (Exhaustive)\": https://nubenetes.com/v1/", 
                 "  - \"The 2026 Vision\": index.md",
                 "  - \"Agentic Video Hub\": videos.md"
             ]

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -96,7 +96,7 @@ markdown_extensions:
   - pymdownx.mark
 
 nav:
-  - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/
+  - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/v1/
   - "The 2026 Vision": index.md
   - "Agentic Video Hub": videos.md
   - "AI":


### PR DESCRIPTION
This PR fixes the navigation loop where the Back to V1 link pointed to the root, which in turn redirected back to V2. It now points specifically to the /v1/ subdirectory gateway.