### PR TITLE
chore: enable manual deploy trigger

### DIFF
--- a/.github/workflows/06.1.main.yml
+++ b/.github/workflows/06.1.main.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Enabling workflow_dispatch to allow manual site updates when automated triggers fail.