### PR TITLE
fix(v2): make H3 technology headers unique to resolve markdownlint errors

### DIFF
--- a/src/v2_video_portal.py
+++ b/src/v2_video_portal.py
@@ -85,8 +85,8 @@ def generate_v2_videos():
             if tech not in seen_techs:
                 seen_techs.append(tech)
         for tech in seen_techs:
-            clean_tech = clean_header(tech)
-            tech_slug = get_slug(tech)
+            clean_tech = clean_header(f"{tech} ({cat})")
+            tech_slug = get_slug(f"{tech} ({cat})")
             content.append(f"    - [{clean_tech}](#{tech_slug})")
 
     content.append("")
@@ -111,8 +111,8 @@ def generate_v2_videos():
             tech_groups[tech].append(v)
             
         for tech in tech_order:
-            clean_tech = clean_header(tech)
-            tech_slug = get_slug(tech)
+            clean_tech = clean_header(f"{tech} ({cat})")
+            tech_slug = get_slug(f"{tech} ({cat})")
             content.append(f"### {clean_tech}")
             
             for v in tech_groups[tech]:

--- a/v2-docs/videos.md
+++ b/v2-docs/videos.md
@@ -5,44 +5,44 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 ## Table of Contents
 
 1. [Fundamentals and Documentaries](#fundamentals-and-documentaries)
-    - [Kubernetes](#kubernetes)
-    - [Jenkins](#jenkins)
+    - [Kubernetes Fundamentals and Documentaries](#kubernetes-fundamentals-and-documentaries)
+    - [Jenkins Fundamentals and Documentaries](#jenkins-fundamentals-and-documentaries)
 2. [Architecture and Cloud Strategy](#architecture-and-cloud-strategy)
-    - [Kubernetes](#kubernetes)
-    - [Red Hat OpenShift](#red-hat-openshift)
-    - [Platform Engineering](#platform-engineering)
-    - [Ruby on Rails](#ruby-on-rails)
-    - [Ruby on Rails / Hotwire](#ruby-on-rails---hotwire)
-    - [Portworx](#portworx)
-    - [HashiCorp Stack Terraform, Vault, Consul, Boundary](#hashicorp-stack-terraform,-vault,-consul,-boundary)
-    - [Modular Monoliths](#modular-monoliths)
-    - [Git](#git)
-    - [Azure DevOps and GitHub Actions](#azure-devops-and-github-actions)
-    - [Distributed Systems Strategy](#distributed-systems-strategy)
-    - [FinOps](#finops)
-    - [GitOps](#gitops)
-    - [Hosted Control Planes](#hosted-control-planes)
-    - [Azure Verified Modules AVM](#azure-verified-modules-avm)
-    - [OpenShift](#openshift)
+    - [Kubernetes Architecture and Cloud Strategy](#kubernetes-architecture-and-cloud-strategy)
+    - [Red Hat OpenShift Architecture and Cloud Strategy](#red-hat-openshift-architecture-and-cloud-strategy)
+    - [Platform Engineering Architecture and Cloud Strategy](#platform-engineering-architecture-and-cloud-strategy)
+    - [Ruby on Rails Architecture and Cloud Strategy](#ruby-on-rails-architecture-and-cloud-strategy)
+    - [Ruby on Rails / Hotwire Architecture and Cloud Strategy](#ruby-on-rails---hotwire-architecture-and-cloud-strategy)
+    - [Portworx Architecture and Cloud Strategy](#portworx-architecture-and-cloud-strategy)
+    - [HashiCorp Stack Terraform, Vault, Consul, Boundary Architecture and Cloud Strategy](#hashicorp-stack-terraform,-vault,-consul,-boundary-architecture-and-cloud-strategy)
+    - [Modular Monoliths Architecture and Cloud Strategy](#modular-monoliths-architecture-and-cloud-strategy)
+    - [Git Architecture and Cloud Strategy](#git-architecture-and-cloud-strategy)
+    - [Azure DevOps and GitHub Actions Architecture and Cloud Strategy](#azure-devops-and-github-actions-architecture-and-cloud-strategy)
+    - [Distributed Systems Strategy Architecture and Cloud Strategy](#distributed-systems-strategy-architecture-and-cloud-strategy)
+    - [FinOps Architecture and Cloud Strategy](#finops-architecture-and-cloud-strategy)
+    - [GitOps Architecture and Cloud Strategy](#gitops-architecture-and-cloud-strategy)
+    - [Hosted Control Planes Architecture and Cloud Strategy](#hosted-control-planes-architecture-and-cloud-strategy)
+    - [Azure Verified Modules AVM Architecture and Cloud Strategy](#azure-verified-modules-avm-architecture-and-cloud-strategy)
+    - [OpenShift Architecture and Cloud Strategy](#openshift-architecture-and-cloud-strategy)
 3. [Infrastructure as Code](#infrastructure-as-code)
-    - [Terraform Enterprise](#terraform-enterprise)
-    - [NetBox](#netbox)
+    - [Terraform Enterprise Infrastructure as Code](#terraform-enterprise-infrastructure-as-code)
+    - [NetBox Infrastructure as Code](#netbox-infrastructure-as-code)
 4. [Developer Productivity](#developer-productivity)
-    - [VS Code](#vs-code)
+    - [VS Code Developer Productivity](#vs-code-developer-productivity)
 5. [Observability and Monitoring](#observability-and-monitoring)
-    - [Prometheus](#prometheus)
+    - [Prometheus Observability and Monitoring](#prometheus-observability-and-monitoring)
 6. [Security and Compliance](#security-and-compliance)
-    - [DevSecOps](#devsecops)
+    - [DevSecOps Security and Compliance](#devsecops-security-and-compliance)
 7. [AI and Future Operations](#ai-and-future-operations)
-    - [Red Hat OpenShift](#red-hat-openshift)
-    - [Generative AI and Large Language Models](#generative-ai-and-large-language-models)
-    - [Red Hat OpenShift AI](#red-hat-openshift-ai)
-    - [Neural Networks](#neural-networks)
-    - [Claude Code](#claude-code)
-    - [LLM Architecture and Post-Training](#llm-architecture-and-post-training)
+    - [Red Hat OpenShift AI and Future Operations](#red-hat-openshift-ai-and-future-operations)
+    - [Generative AI and Large Language Models AI and Future Operations](#generative-ai-and-large-language-models-ai-and-future-operations)
+    - [Red Hat OpenShift AI AI and Future Operations](#red-hat-openshift-ai-ai-and-future-operations)
+    - [Neural Networks AI and Future Operations](#neural-networks-ai-and-future-operations)
+    - [Claude Code AI and Future Operations](#claude-code-ai-and-future-operations)
+    - [LLM Architecture and Post-Training AI and Future Operations](#llm-architecture-and-post-training-ai-and-future-operations)
 
 ## Fundamentals and Documentaries
-### Kubernetes
+### Kubernetes Fundamentals and Documentaries
 ??? note "🎬 Kubernetes: The Documentary [PART 1] | `Kubernetes`"
     !!! info "Architectural Summary"
         This documentary chronicles the origin of Kubernetes from Google's internal cluster managers Borg and Omega, highlighting the pivotal architectural transition from virtual machines to containerized orchestration. Understanding this evolution is critical for modern cloud-native architects, as it reveals the foundational design patterns—such as the reconciliation loop, declarative APIs, and decoupled control planes—that continue to govern state-of-the-art distributed systems and platform engineering.
@@ -63,7 +63,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Jenkins
+### Jenkins Fundamentals and Documentaries
 ??? note "🎬 Jenkins Tutorials | `Jenkins`"
     !!! info "Architectural Summary"
         This comprehensive video series details core Jenkins CI/CD automation techniques, including Pipeline-as-Code implementations and system management best practices. In a 2026 cloud-native context, mastering Jenkins remains critical for orchestrating complex build pipelines, bridging the gap between legacy infrastructure and modern Kubernetes deployment targets. The tutorials provide foundational architectural patterns for establishing scalable, automated, and reproducible continuous integration workflows across distributed enterprise environments.
@@ -75,7 +75,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     </center>
 
 ## Architecture and Cloud Strategy
-### Kubernetes
+### Kubernetes Architecture and Cloud Strategy
 ??? note "🎬 Kubernetes for SysAdmins | Kelsey Hightower at PuppetConf | Talk & Demo | `Kubernetes`"
     !!! info "Architectural Summary"
         This seminal presentation outlines the paradigm shift from traditional imperative configuration management to declarative, container-orchestrated infrastructure by redefining the operating contract between applications and underlying systems. Viewed from a 2026 cloud-native perspective, Kelsey Hightower's early demonstrations of self-healing workloads, automated bin-packing, and custom controllers for automated TLS provisioning serve as the foundational blueprint for modern platform engineering. The architectural concepts covered—specifically decoupling stateful storage and leveraging native service discovery—remain highly relevant for engineers transitioning from static sysadmin practices to dynamic API-driven control loops.
@@ -96,7 +96,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Red Hat OpenShift
+### Red Hat OpenShift Architecture and Cloud Strategy
 ??? note "🎬 Thursday morning general session - May 9 - Red Hat Summit 2019 | `Red Hat OpenShift`"
     !!! info "Architectural Summary"
         This session outlines the architectural deployment of Red Hat OpenShift as a unified hybrid cloud platform, demonstrating how enterprise Kubernetes orchestrates complex workloads across multi-cloud and edge environments. It highlights critical integrations with GPU acceleration and AI/ML pipelines, establishing a robust blueprint for modern MLOps and scalable cloud-native operations.
@@ -117,7 +117,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Platform Engineering
+### Platform Engineering Architecture and Cloud Strategy
 ??? note "🎬 What is Platform Engineering and how it fits into DevOps and Cloud world | `Platform Engineering`"
     !!! info "Architectural Summary"
         This video details the evolution of cloud operations into Platform Engineering, focusing on the architecture and implementation of Internal Developer Platforms (IDPs) to mitigate developer cognitive load. By establishing standardized 'golden paths' through Infrastructure as Code (IaC) and self-service APIs, organizations can balance developer autonomy with rigorous governance, security, and compliance. This paradigm shift optimizes resource provisioning and modernizes DevOps workflows for highly scalable, cloud-native environments.
@@ -128,7 +128,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Ruby on Rails
+### Ruby on Rails Architecture and Cloud Strategy
 ??? note "🎬 David Heinemeier Hansson: Microservices vs. Monolith | `Ruby on Rails`"
     !!! info "Architectural Summary"
         In this discussion, David Heinemeier Hansson critiques the dogmatic adoption of microservices, highlighting how they introduce substantial operational complexity, network latency, and cognitive load compared to a well-structured monolith. He champions the 'Majestic Monolith' as a pattern that maximizes developer velocity and reduces organizational overhead by keeping the deployment domain unified. For modern cloud-native architectures, this perspective serves as a crucial counterweight to microservice fatigue, driving the industry toward highly-optimized modular monoliths that simplify infrastructure and cut cloud spend.
@@ -139,7 +139,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Ruby on Rails / Hotwire
+### Ruby on Rails / Hotwire Architecture and Cloud Strategy
 ??? note "🎬 The creator of Rails on JavaScript FE vs. Classic Server-side Rendering | `Ruby on Rails / Hotwire`"
     !!! info "Architectural Summary"
         David Heinemeier Hansson critiques the complexity of modern Single Page Application (SPA) architectures, advocating instead for the 'Majestic Monolith' and HTML-over-the-wire (Hotwire) to keep application logic unified on the server. In a 2026 cloud-native context, this paradigm challenges the overhead of decoupled micro-frontends by proving that server-side rendering (SSR) combined with lightweight HTML streaming dramatically simplifies deployment pipelines, reduces client-side resource consumption, and lowers data egress costs. This architectural approach optimizes for operational efficiency, enabling smaller engineering teams to build highly responsive, production-grade applications without managing complex API contract synchronizations.
@@ -150,7 +150,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Portworx
+### Portworx Architecture and Cloud Strategy
 ??? note "🎬 Murli Thirumale | KubeCon CloudNativeCon EU 2023 | `Portworx`"
     !!! info "Architectural Summary"
         This discussion outlines how enterprise platform engineering teams leverage Portworx to deliver automated, resilient Database-as-a-Service (DBaaS) capabilities directly on Kubernetes. By abstracting multi-cloud storage, disaster recovery, and data security, it highlights architectural strategies essential for scaling stateful cloud-native workloads. For a 2026 cloud-native landscape, these unified data management planes are critical for mitigating multi-cloud lock-in, controlling cloud spend, and accelerating application delivery.
@@ -161,7 +161,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### HashiCorp Stack Terraform, Vault, Consul, Boundary
+### HashiCorp Stack Terraform, Vault, Consul, Boundary Architecture and Cloud Strategy
 ??? note "🎬 Building a developer platform? Ask these questions. | `HashiCorp Stack (Terraform, Vault, Consul, Boundary)`"
     !!! info "Architectural Summary"
         This session details how to build secure, scalable developer platforms by defining 'golden paths' using HashiCorp's suite of automation tools, including Terraform, Vault, Consul, and Boundary. It provides a strategic framework for resolving key platform engineering challenges such as Day 2 operations, infrastructure dependency mapping, secure access control, and seamless local-to-remote environment transitions. By abstracting cloud complexity, the session demonstrates how to deliver high-velocity self-service capabilities to development teams while ensuring governance and security compliance.
@@ -172,7 +172,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Modular Monoliths
+### Modular Monoliths Architecture and Cloud Strategy
 ??? note "🎬 ¿De verdad son necesarios los microservicios? | `Modular Monoliths`"
     !!! info "Architectural Summary"
         This video critically evaluates the over-engineering of distributed systems, examining whether the operational overhead, network latency, and complexity of microservices are justified for most projects. In a 2026 cloud-native landscape focusing heavily on cost optimization and developer velocity, it advocates for a pragmatic, domain-driven approach, highlighting modular monoliths as a powerful alternative before prematurely adopting microservices.
@@ -183,7 +183,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Git
+### Git Architecture and Cloud Strategy
 ??? note "🎬 Branching Strategies Explained | `Git`"
     !!! info "Architectural Summary"
         This guide provides a comprehensive architectural evaluation of various Git branching strategies, including Trunk-Based Development, Feature Branches, Git Flow, and Environment Branches, weighing their impacts on delivery velocity. For a 2026 cloud-native landscape, it emphasizes how moving toward trunk-based development or short-lived feature branches is essential for optimizing continuous integration (CI) pipelines, minimizing integration debt, and enabling rapid, automated deployments to Kubernetes and cloud environments.
@@ -194,7 +194,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Azure DevOps and GitHub Actions
+### Azure DevOps and GitHub Actions Architecture and Cloud Strategy
 ??? note "🎬 Panel: Azure DevOps vs. GitHub Actions | `Azure DevOps & GitHub Actions`"
     !!! info "Architectural Summary"
         This panel discussion provides a comprehensive architectural comparison between Azure DevOps and GitHub Actions, focusing on enterprise governance, extensibility, and CI/CD workflow migration strategies. It outlines decision frameworks for hybrid platform setups, highlighting how organizations can leverage GitHub Actions for modern cloud-native developer velocity while maintaining Azure DevOps for mature project management, test plans, and strict regulatory compliance. Essential for cloud architects planning long-term toolchain evolution, this session clarifies integration pathways and future-proof migration strategies.
@@ -205,7 +205,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Distributed Systems Strategy
+### Distributed Systems Strategy Architecture and Cloud Strategy
 ??? note "🎬 Elon Musk talks Twitter, Tesla and how his brain works — live at TED2022 | `Distributed Systems Strategy`"
     !!! info "Architectural Summary"
         This systemic interview highlights architectural principles around open-sourcing core algorithms to enforce platform transparency and trust, directly paralleling modern GitOps, policy-as-code, and zero-trust verification frameworks in Cloud Native environments. Additionally, the insights on extreme manufacturing automation offer critical design lessons for 2026 edge computing, emphasizing the necessity of closed-loop automation, event-driven orchestration, and radical simplification of complex distributed infrastructures.
@@ -216,7 +216,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### FinOps
+### FinOps Architecture and Cloud Strategy
 ??? note "🎬 The Brutal Truth Behind Tech Layoffs | `FinOps`"
     !!! info "Architectural Summary"
         This analysis dissects the macroeconomic shift from hyper-growth talent hoarding to hyper-efficiency, highlighting the systemic collapse of bloated engineering teams in favor of lean, automated operations. For a 2026 cloud-native landscape, this underscores the critical role of platform engineering and robust FinOps architectures designed to maximize resource utilization while minimizing human-in-the-loop operational overhead. Architects must leverage these insights to build self-healing, highly automated platforms that successfully decouple organizational scale from headcount.
@@ -227,7 +227,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### GitOps
+### GitOps Architecture and Cloud Strategy
 ??? note "🎬 GitOps Guide to the Galaxy | `GitOps`"
     !!! info "Architectural Summary"
         Every other Thursday at 3pm ET hosts Hilliary Lipsig and Jonathan Rickard dive into everything in the GitOps universe, from solutions to common problems in end-to-end CICD pipelines, to creating Git workflows. This series explores how GitOps enhances modern application delivery and discusses the latest news around best practices and Cloud Native architecture.
@@ -238,7 +238,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Hosted Control Planes
+### Hosted Control Planes Architecture and Cloud Strategy
 ??? note "🎬 GitOps Guide to the Galaxy: Hosted Control Planes (HyperShift) | `Hosted Control Planes`"
     !!! info "Architectural Summary"
         This session from the GitOps Guide to the Galaxy deconstructs the architecture of Hosted Control Planes (HCP), also known as HyperShift. It explores how HCP decouples the Kubernetes control plane from worker nodes, hosting it as a scalable workload on a management cluster to drastically reduce operational overhead, improve provisioning speed, and optimize resource utilization. For 2026 platform engineering, mastering this pattern is essential for managing large-scale, multi-tenant Kubernetes fleets with high-density efficiency and strong isolation.
@@ -249,7 +249,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Azure Verified Modules AVM
+### Azure Verified Modules AVM Architecture and Cloud Strategy
 ??? note "🎬 Building Secure, Well‑Architected Azure Workloads with Azure Verified Modules and GitHub Copilot | `Azure Verified Modules (AVM)`"
     !!! info "Architectural Summary"
         Azure Verified Modules (AVM) is the official Microsoft infrastructure-as-code module library for both Bicep and Terraform. This session explores how AVM standardizes deployments according to the Azure Well-Architected Framework by default, shipping with high-impact security defaults like zone redundancy and disabled public IPs. It introduces Spec-Driven Development with GitHub Copilot using the "Spec Kit" (an 8-step framework from constitution to implementation). By turning non-deterministic AI prompts into reliable, repeatable builds, architects can leverage AI as a trusted foundation for secure and compliant Azure workload orchestration.
@@ -260,7 +260,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### OpenShift
+### OpenShift Architecture and Cloud Strategy
 ??? note "🎬 Fran Heeran, Red Hat | Red Hat Summit 2026 | `OpenShift`"
     !!! info "Architectural Summary"
         In this Red Hat Summit 2026 interview, Fran Heeran details how telecommunications providers are shifting from heavily siloed infrastructure to unified cloud-native architectures. By leveraging OpenShift Virtualization, telcos can centrally manage both legacy virtual machines and modern containers across core networks and the far edge, accelerating deployments up to 50%. This unified architecture additionally enables sovereign cloud offerings and closed-loop network automation by feeding AI outputs directly into Ansible-driven remediation workflows.
@@ -272,7 +272,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     </center>
 
 ## Infrastructure as Code
-### Terraform Enterprise
+### Terraform Enterprise Infrastructure as Code
 ??? note "🎬 Standardizing infrastructure automation with Terraform Enterprise | `Terraform Enterprise`"
     !!! info "Architectural Summary"
         This presentation details AXA Group's cloud migration strategy (ATLAS) utilizing Terraform Enterprise as the cornerstone of their multi-cloud and private IaaS migration factory. It highlights how a highly regulated financial enterprise standardizes infrastructure-as-code (IaC) practices across multiple global subsidiaries to accelerate cloud adoption while maintaining governance. For a 2026 cloud-native landscape, this case study provides key insights into scaling self-service provisioning, implementing policy-as-code, and automating multi-tenant enterprise architectures at massive scale.
@@ -283,7 +283,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### NetBox
+### NetBox Infrastructure as Code
 ??? note "🎬 NetBox Zero To Hero | `NetBox`"
     !!! info "Architectural Summary"
         NetBox serves as the foundational source of truth for modern network automation by integrating IP Address Management (IPAM) and Data Center Infrastructure Management (DCIM) into a unified database. In a 2026 Cloud Native ecosystem, it empowers Infrastructure as Code (IaC) pipelines to dynamically query and enforce intended network state via robust APIs, effectively eliminating configuration drift. This architectural approach bridges the gap between physical hardware tracking and automated, declarative network orchestration across complex hybrid environments.
@@ -295,7 +295,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     </center>
 
 ## Developer Productivity
-### VS Code
+### VS Code Developer Productivity
 ??? note "🎬 Remote VS Code with Dev Tunnels: access the editor from your browser | `VS Code`"
     !!! info "Architectural Summary"
         In this tutorial, Gisela Torres explains the architecture and application of VS Code Dev Tunnels to enable secure remote access to local development environments. Dev Tunnels establish a secure, encrypted connection to VS Code without requiring complex VPNs or firewall modifications, allowing developers to connect from any web browser or secondary editor instance. For 2026 developer productivity, this simplifies remote workspace orchestration and collaborative debugging in cloud-native platforms. [SPANISH CONTENT]
@@ -307,7 +307,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     </center>
 
 ## Observability and Monitoring
-### Prometheus
+### Prometheus Observability and Monitoring
 ??? note "🎬 Prometheus: The Documentary | `Prometheus`"
     !!! info "Architectural Summary"
         This documentary explores the architectural genesis of Prometheus at SoundCloud, detailing how the shift to microservices necessitated a fundamental pivot from host-based monitoring to a pull-based, multi-dimensional metric data model. In a 2026 cloud-native context, understanding these foundational design decisions—specifically the trade-offs of localized TSDB storage, HTTP pull mechanics, and PromQL—is vital for architecting self-healing, high-cardinality observability pipelines across distributed, edge, and hybrid-cloud environments.
@@ -319,7 +319,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     </center>
 
 ## Security and Compliance
-### DevSecOps
+### DevSecOps Security and Compliance
 ??? note "🎬 What is DevSecOps? DevSecOps explained in 8 Mins | `DevSecOps`"
     !!! info "Architectural Summary"
         This video details the transition from traditional, late-stage security audits to DevSecOps, explaining how shifting security left eliminates deployment bottlenecks in fast-paced delivery pipelines. It covers the automation of static analysis (SAST), software composition analysis (SCA), and container scanning directly within CI/CD workflows. In a 2026 cloud-native context, this paradigm is critical for securing ephemeral microservices and maintaining continuous compliance without sacrificing deployment velocity.
@@ -331,7 +331,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     </center>
 
 ## AI and Future Operations
-### Red Hat OpenShift
+### Red Hat OpenShift AI and Future Operations
 ??? note "🎬 Thursday morning general session - May 9 - Red Hat Summit 2019 | `Red Hat OpenShift`"
     !!! info "Architectural Summary"
         This session outlines the architectural enablement of cloud-native AI/ML workloads by integrating Red Hat OpenShift with NVIDIA GPU acceleration and automated MLOps platforms like H2O.ai and ProphetStor. It demonstrates how standardizing on a Kubernetes-based hybrid cloud substrate abstracts heterogeneous hardware environments, facilitating deterministic scaling, resource orchestration, and cognitive monitoring for high-performance AI pipelines. This unified operational model serves as a foundational blueprint for modern enterprise AI-platform engineering and edge computing architectures.
@@ -342,7 +342,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Generative AI and Large Language Models
+### Generative AI and Large Language Models AI and Future Operations
 ??? note "🎬 Artificial Intelligence | 60 Minutes Full Episodes | `Generative AI and Large Language Models`"
     !!! info "Architectural Summary"
         This documentary anthology traces the rapid evolution of artificial intelligence from early deep learning implementations to advanced generative AI systems like Google's Bard and OpenAI's ChatGPT. For 2026 cloud-native architectures, these developments highlight the critical need for integrating scalable AI model orchestration, strict ethical guardrails, and secure data pipelines directly into enterprise platform engineering. Understanding these socio-technical shifts assists cloud architects in designing resilient, compliant AI-integrated infrastructures that balance massive computational demands with robust operational governance.
@@ -353,7 +353,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Red Hat OpenShift AI
+### Red Hat OpenShift AI AI and Future Operations
 ??? note "🎬 Red Hat OpenShift AI overview | `Red Hat OpenShift AI`"
     !!! info "Architectural Summary"
         Red Hat OpenShift AI provides an enterprise-grade MLOps platform built on Kubernetes that standardizes the training, tuning, serving, and monitoring of foundation and predictive AI models across hybrid and multi-cloud environments. By integrating open-source frameworks like Jupyter, PyTorch, and KServe with certified hardware accelerators, it delivers a secure, consistent, and self-service environment for platform and data science teams. This architecture ensures robust AI governance, operational scalability, and accelerated time-to-market for intelligent cloud-native applications.
@@ -364,7 +364,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Neural Networks
+### Neural Networks AI and Future Operations
 ??? note "🎬 ¿Qué es una Red Neuronal? Parte 1 : La Neurona | DotCSV | `Neural Networks`"
     !!! info "Architectural Summary"
         This video deconstructs the foundational mathematical and algorithmic mechanics of a single artificial neuron, illustrating its direct relationship with linear regression, weights, biases, and activation functions. In a 2026 cloud-native landscape, mastering these core neural principles is critical for platform architects optimizing distributed micro-models and real-time AI inference engines deployed on Kubernetes-driven edge and cloud infrastructure. This granular understanding enables more efficient hardware acceleration profiling (GPUs/vGPUs/TPUs) and smarter resource allocation for decentralized machine learning pipelines.
@@ -375,7 +375,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### Claude Code
+### Claude Code AI and Future Operations
 ??? note "🎬 Mastering Claude Code in 30 minutes | `Claude Code`"
     !!! info "Architectural Summary"
         This technical session explores the architecture and implementation of Claude Code, Anthropic's agentic CLI designed for autonomous, multi-step engineering tasks. It details how the tool leverages the Model Context Protocol (MCP) to integrate with external data sources and documentation, enabling a self-healing development cycle where the agent autonomously reads code, executes shell commands, and iterates through test-driven development (TDD) loops. For 2026 platform engineers, mastering these agentic workflows is critical for scaling complex refactoring, managing cognitive load in large-scale repositories, and establishing robust human-in-the-loop (HITL) governance for AI-driven infrastructure operations.
@@ -386,7 +386,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
 
     </center>
 
-### LLM Architecture and Post-Training
+### LLM Architecture and Post-Training AI and Future Operations
 ??? note "🎬 Stanford CS229: Building Large Language Models (LLMs) | `LLM Architecture & Post-Training`"
     !!! info "Architectural Summary"
         This Stanford CS229 technical deep-dive deconstructs the transition from raw autoregressive language models to instruction-tuned assistants, focusing on the systems orchestration required for 2026 AI infrastructure. It explores critical patterns in tokenization (BPE/Sub-word), parameter-efficient fine-tuning (PEFT/LoRA), and the shift from RLHF to Direct Preference Optimization (DPO) to simplify model alignment pipelines. For cloud architects, the lecture provides a foundational framework for optimizing the "Compute-to-Token" ratio and managing memory constraints (KV Cache) in distributed distributed inference environments, while advocating for LLM-as-a-Judge automated evaluation loops for scalable model governance.


### PR DESCRIPTION
This PR fixes the duplicate heading errors (MD024) in v2-docs/videos.md by appending the parent category name to each H3 technology heading, ensuring uniqueness across the page.