### PR TITLE
feat(v2): add Agentic DevOps Live playlist with AI summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.3.10]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.3.10) - 2026-05-27
+
+### Added
+- **Agentic DevOps Live Playlist**: Integrated the Microsoft/GitHub "Agentic DevOps Live" series into the V2 Video Hub under the AI and Future Operations category, detailing SRE agents, Copilot App Mod agents, and autonomous development loops.
+
 ## [[2.3.9]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.3.9) - 2026-05-27
 
 ### Added

--- a/v2-docs/videos.md
+++ b/v2-docs/videos.md
@@ -40,6 +40,7 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     - [Neural Networks AI and Future Operations](#neural-networks-ai-and-future-operations)
     - [Claude Code AI and Future Operations](#claude-code-ai-and-future-operations)
     - [LLM Architecture and Post-Training AI and Future Operations](#llm-architecture-and-post-training-ai-and-future-operations)
+    - [Agentic DevOps AI and Future Operations](#agentic-devops-ai-and-future-operations)
 
 ## Fundamentals and Documentaries
 ### Kubernetes Fundamentals and Documentaries
@@ -394,5 +395,16 @@ Welcome to the **Agentic Video Hub**. This section presents a logical, architect
     <center markdown="1">
 
     <iframe width="720" height="405" src="https://www.youtube.com/embed/9vM4p9NN0Ts" title="Stanford CS229: Building Large Language Models (LLMs)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" style="border: 1px solid var(--md-typeset-table-color); border-radius: 8px;"></iframe>
+
+    </center>
+
+### Agentic DevOps AI and Future Operations
+??? note "🎬 Agentic DevOps Live | `Agentic DevOps`"
+    !!! info "Architectural Summary"
+        This official live series explores the paradigm shift from traditional CI/CD pipelines to autonomous, agent-driven operations (Agentic DevOps). It covers technical deep-dives into Azure SRE Agents for automated root cause analysis and proactive reliability, GitHub Copilot App Mod Agents for modernizing legacy systems at scale, and AI-powered workflows across GitHub and Azure DevOps. Essential for platform engineers designing self-healing environments and scalable human-in-the-loop AI governance in 2026.
+
+    <center markdown="1">
+
+    <iframe width="720" height="405" src="https://www.youtube.com/embed/videoseries?list=PLmsFUfdnGr3w9BdWjQGAwV7UPW0kspwOp" title="Agentic DevOps Live" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy" style="border: 1px solid var(--md-typeset-table-color); border-radius: 8px;"></iframe>
 
     </center>


### PR DESCRIPTION
This PR adds the Microsoft/GitHub 'Agentic DevOps Live' playlist to the V2 Video Hub under the AI and Future Operations category, enrichs the database inventory, and bumps version to 2.3.10.