### PR TITLE
fix: remove offline plugin, add digest placeholders, enforce clean URL mandate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,5 +86,8 @@ python3 -m src.v2_optimizer --render-only    # Render V2 portal (no AI calls)
 - Inventory fields: `discovered_at` (ISO), `last_ai_eval` (ISO), `company`, `geo_region` must be preserved during merges
 - The `update_inventory_entry()` function preserves `discovered_at` — never overwrite it with new data
 
+## URL Policy: Clean URLs, No .html Suffix
+Both V1 and V2 MUST use `use_directory_urls: true` in their mkdocs.yml. This produces clean URLs like `/kubernetes/` instead of `/kubernetes.html`. **NEVER** enable the `offline` plugin — it forces `.html` suffixes on all URLs, breaking SEO and existing deep-links. This is a hard rule.
+
 ## RSS/Twitter Sources
 RSS feeds are limited to those that actually work (many block bots). Don't add new RSS feeds without testing. Current working feeds are defined in `data/curation_sources.yaml`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -401,3 +401,6 @@ This repository uses **Gitflow**. All agents and automated processes MUST follow
 - **Major**: breaking changes or architectural shifts
 - **Minor**: new features (modules, digest categories, new pipelines)
 - **Patch**: bug fixes, config tweaks, content updates
+
+## URL Policy: Clean URLs (Mandatory)
+Both V1 (`mkdocs.yml`) and V2 (`v2-mkdocs.yml`) MUST use `use_directory_urls: true` to produce clean URLs like `/kubernetes/` instead of `/kubernetes.html`. **NEVER** enable the MkDocs `offline` plugin — it forces `.html` suffixes on all URLs, breaking SEO authority and thousands of existing deep-links. This is a hard, non-negotiable rule.

--- a/README.md
+++ b/README.md
@@ -439,6 +439,10 @@ The V2 portal includes an **AI-powered Intelligence Digest** system that surface
 - **Minify Plugin** for production HTML optimization
 - **12 Stub Pages Merged** into parent categories with automatic redirects (e.g., `react.md` → `javascript.md`, `chef.md` → `ansible.md`, `oauth.md` → `securityascode.md`)
 
+#### V2 URL Policy (June 2026)
+- **Clean URLs enforced**: Both V1 and V2 use `use_directory_urls: true` producing SEO-friendly URLs (e.g., `/kubernetes/` not `/kubernetes.html`).
+- **Offline plugin permanently removed**: The MkDocs `offline` plugin forces `.html` suffixes on all URLs, breaking thousands of existing deep-links and SEO authority. It is explicitly forbidden in both `CLAUDE.md` and `GEMINI.md` mandates.
+
 ### 5.3. Architecture Comparison Matrix: V1 vs. V2
 To better understand the dual-nature of the project, the following matrix details the technical and philosophical differences between the two editions:
 

--- a/v2-docs/industry-digest.md
+++ b/v2-docs/industry-digest.md
@@ -1,0 +1,9 @@
+# 🌍 Nubenetes Industry & Geo Intelligence Digest
+
+!!! tip "Nubenetes Intelligence Digest"
+    AI-curated ranking of the most impactful resources, updated monthly.
+
+!!! info "Coming Soon"
+    The Industry & Geo Digest will be populated automatically when the monthly pipeline runs with Gemini AI ranking. Check back after the next curation cycle.
+
+    **4 geographic categories** (Americas, Europe, Spain, Asia-Pacific) will surface industry-relevant resources classified by company and region.

--- a/v2-docs/tech-digest.md
+++ b/v2-docs/tech-digest.md
@@ -1,0 +1,9 @@
+# 📊 Nubenetes Tech & Cloud Intelligence Digest
+
+!!! tip "Nubenetes Intelligence Digest"
+    AI-curated ranking of the most impactful resources, updated monthly.
+
+!!! info "Coming Soon"
+    The Intelligence Digest will be populated automatically when the monthly pipeline runs with Gemini AI ranking. Check back after the next curation cycle.
+
+    **26 categories** across Tech Core, Platform & Ops, and Cloud & Enterprise dimensions will surface the most relevant resources from the last 3, 6, and 12 months.

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -63,7 +63,6 @@ plugins:
       logo: favicon-ultra.png
   - tags:
       tags_file: tags.md
-  - offline
   - minify:
       minify_html: true
   - rss:


### PR DESCRIPTION
## Summary
- Remove `offline` plugin that was causing `.html` suffixes on all V2 URLs
- Add placeholder digest pages to prevent 404 before first Gemini run
- Add clean URL mandate to CLAUDE.md and GEMINI.md
- Update README

## Test plan
- [ ] Verify V2 URLs no longer have `.html` suffix after deployment
- [ ] Verify `/tech-digest/` and `/industry-digest/` return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)