### PR TITLE
feat: Intelligence Digest hero card and mini-preview on index

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -352,6 +352,22 @@ a {
   border-color: #2dd4bf !important;
 }
 
+.hero-badge-card--amber {
+  border-color: rgba(245, 158, 11, 0.2);
+  background: rgba(245, 158, 11, 0.02);
+}
+.hero-badge-card--amber:hover {
+  background: rgba(245, 158, 11, 0.06) !important;
+  box-shadow: 0 8px 24px rgba(245, 158, 11, 0.18);
+  border-color: #f59e0b !important;
+}
+
+.hero-badge-icon {
+  font-size: 2rem;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
 .hero-badge-title {
   font-weight: bold;
   font-size: 0.95rem;
@@ -362,6 +378,56 @@ a {
   font-size: 0.78rem;
   color: var(--md-primary-fg-color--dark);
   margin-top: 4px;
+}
+
+/* Intelligence Digest mini-preview on index */
+.digest-preview {
+  background: rgba(245, 158, 11, 0.04);
+  border: 1px solid rgba(245, 158, 11, 0.15);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin: 24px 0;
+}
+.digest-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.digest-preview-title {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--md-primary-fg-color);
+}
+.digest-preview-link {
+  font-size: 0.8rem;
+  color: #f59e0b;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.digest-preview-link:hover { text-decoration: underline; }
+.digest-preview-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.digest-preview-list li {
+  padding: 5px 0;
+  border-bottom: 1px solid rgba(245, 158, 11, 0.08);
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.digest-preview-list li:last-child { border-bottom: none; }
+.digest-preview-cat {
+  font-size: 0.7rem;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.1);
+  border-radius: 4px;
+  padding: 1px 6px;
+  white-space: nowrap;
 }
 
 /* Hero Showcase Image wrapper (4 cars in a container) */

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1055,6 +1055,45 @@ class V2VisionEngine:
             "    - **Status**: The system is incrementally processing pending resources to complete the knowledge graph.\n"
         )
 
+        # Build digest-preview block for index
+        priority_cats = [
+            "Kubernetes & Orchestration", "AI & Agents", "Security & Compliance",
+            "Infrastructure as Code", "Observability, SRE & Testing", "CI/CD & GitOps"
+        ]
+        cat_short = {
+            "Kubernetes & Orchestration": "Kubernetes",
+            "AI & Agents": "AI & Agents",
+            "Security & Compliance": "Security",
+            "Infrastructure as Code": "IaC",
+            "Observability, SRE & Testing": "Observability",
+            "CI/CD & GitOps": "CI/CD",
+        }
+        digest_preview_md = ""
+        if digest_data and "3_months" in digest_data:
+            preview_items = []
+            for cat in priority_cats:
+                entries = digest_data["3_months"].get(cat, [])
+                if entries:
+                    e = entries[0]
+                    title = nuclear_strip(e.get("title", ""))[:65]
+                    preview_items.append((cat_short.get(cat, cat), title, e.get("url", "#")))
+            if preview_items:
+                rows = "\n".join(
+                    f'    <li><span class="digest-preview-cat">{c}</span> <a href="{u}">{t}</a></li>'
+                    for c, t, u in preview_items[:5]
+                )
+                digest_preview_md = (
+                    '<div class="digest-preview">\n'
+                    '  <div class="digest-preview-header">\n'
+                    '    <span class="digest-preview-title">📊 Intelligence Digest — Top Picks (Last 3 Months)</span>\n'
+                    '    <a href="./tech-digest/" class="digest-preview-link">View all 22 categories →</a>\n'
+                    '  </div>\n'
+                    '  <ul class="digest-preview-list">\n'
+                    f'{rows}\n'
+                    '  </ul>\n'
+                    '</div>\n\n'
+                )
+
         index_md = (
             "# Nubenetes Elite Portal (V2) | Awesome Kubernetes & Cloud [![Awesome](https://cdn.jsdelivr.net/gh/sindresorhus/awesome@d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)\n\n"
             "!!! tip \"Nubenetes V2 Elite Portal: AI-Curated & High-Density\"\n"
@@ -1093,6 +1132,13 @@ class V2VisionEngine:
             "      <div class=\"hero-badge-subtitle\">Agentic Ecosystem</div>\n"
             "    </div>\n"
             "  </a>\n"
+            "  <a href=\"./tech-digest/\" style=\"text-decoration: none; color: inherit; display: block;\">\n"
+            "    <div class=\"hero-badge-card hero-badge-card--amber\">\n"
+            "      <div class=\"hero-badge-icon\">📊</div>\n"
+            "      <div class=\"hero-badge-title\">Intelligence Digest</div>\n"
+            "      <div class=\"hero-badge-subtitle\">Top picks · 3/6/12 months</div>\n"
+            "    </div>\n"
+            "  </a>\n"
             "  <a href=\"./videos/\" style=\"text-decoration: none; color: inherit; display: block;\">\n"
             "    <div class=\"hero-badge-card hero-badge-card--pink\">\n"
             "      <img src=\"/images/video_hub_logo.png\" alt=\"Agentic Video Hub\"/>\n"
@@ -1113,6 +1159,7 @@ class V2VisionEngine:
             "the system selects only the most relevant, stable, and impactful resources for the modern Cloud Native ecosystem (2026 and beyond).\n\n"
             f"{coverage_info}\n\n"
             f"<center markdown=\"1\">\n{mosaic_html}\n</center>\n\n"
+            f"{digest_preview_md}"
             f"{pulse_md}\n\n"
             "## Strategic Dimensions\n"
             "- **[🎥 Agentic Video Hub (Architectural Summary)](./videos/index.md)**\n\n"

--- a/v2-docs/index.md
+++ b/v2-docs/index.md
@@ -39,6 +39,13 @@
       <div class="hero-badge-subtitle">Agentic Ecosystem</div>
     </div>
   </a>
+  <a href="./tech-digest/" style="text-decoration: none; color: inherit; display: block;">
+    <div class="hero-badge-card hero-badge-card--amber">
+      <div class="hero-badge-icon">📊</div>
+      <div class="hero-badge-title">Intelligence Digest</div>
+      <div class="hero-badge-subtitle">Top picks · 3/6/12 months</div>
+    </div>
+  </a>
   <a href="./videos/" style="text-decoration: none; color: inherit; display: block;">
     <div class="hero-badge-card hero-badge-card--pink">
       <img src="/images/video_hub_logo.png" alt="Agentic Video Hub"/>
@@ -115,6 +122,20 @@
 
 </div>
 </center>
+
+<div class="digest-preview">
+  <div class="digest-preview-header">
+    <span class="digest-preview-title">📊 Intelligence Digest — Top Picks (Last 3 Months)</span>
+    <a href="./tech-digest/" class="digest-preview-link">View all 22 categories →</a>
+  </div>
+  <ul class="digest-preview-list">
+    <li><span class="digest-preview-cat">Kubernetes</span> <a href="https://www.apptio.com/products/kubecost/?src=kc-com">Kubecost — real-time cost allocation for multi-cluster K8s</a></li>
+    <li><span class="digest-preview-cat">AI & Agents</span> <a href="https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview">Claude Code CLI — agentic AI coding assistant</a></li>
+    <li><span class="digest-preview-cat">Security</span> <a href="https://github.com/policy-hub/policy-hub-cli">PolicyHub CLI — searchable Rego policy library</a></li>
+    <li><span class="digest-preview-cat">IaC</span> <a href="https://github.com/shuaibiyy/awesome-tf">Awesome Terraform — curated Terraform resources</a></li>
+    <li><span class="digest-preview-cat">Observability</span> <a href="https://grafana.com/blog/how-to-manage-high-cardinality-metrics-in-prometheus-and-kubernetes">Grafana: High cardinality metrics in Prometheus & K8s</a></li>
+  </ul>
+</div>
 
 ## The Agentic Pulse
 - **(2026)** [**==abarrak.gitbook.io: Linux SysOps Handbook 🌟==**](https://abarrak.gitbook.io/linux-sysops-handbook) 🌟🌟🌟🌟


### PR DESCRIPTION
## Changes
- **Hero card**: amber-colored card between AI & MCP and Video Hub, links to /tech-digest/
- **Digest preview**: 5-item list above Agentic Pulse, 1 top pick per priority category, auto-generated from news_digest.json
- **CSS**: new amber card variant, digest-preview component with category chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)