### PR TITLE
feat(v2): category-first digest layout for a navigable right-hand TOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.9.15]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.9.15) - 2026-06-19
+
+### Changed
+- **Navigable Intelligence Digest TOC**: The Tech & Cloud and Industry & Geo digest pages now show their sections in the right-hand "On this page" TOC. They were rendered period-first (three time-window tabs, each nesting every category as **bold text**), so the pages had zero real headings and an empty TOC. Inverted the layout in `_generate_digest_pages()` to **category-first**: each category is a real `##` heading (Kubernetes & Orchestration, Containers & Runtime, … / Americas, Europe, Spain, Asia-Pacific), with the three time-windows (3 / 6 / 12 months) as content tabs *inside* each category. The TOC now lists all 22 tech categories and 4 geo regions exactly once, headings sit at column 0 (no more MD023 workaround), and the tabbed UX is preserved.
+
 ## [[2.9.14]](https://github.com/nubenetes/awesome-kubernetes/releases/tag/v2.9.14) - 2026-06-19
 
 ### Changed

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -971,14 +971,21 @@ class V2VisionEngine:
             md += f"# {title}\n\n"
             md += "!!! tip \"Nubenetes Intelligence Digest\"\n"
             md += "    AI-curated ranking of the most impactful resources, updated monthly.\n\n"
-            for period_key, period_label in period_labels.items():
-                md += f'=== "{period_label}"\n\n'
-                period_data = digest_data.get(period_key, {})
-                for cat in categories:
-                    items = period_data.get(cat, [])
+            # Category-first layout: each category is a real H2 heading (at column 0)
+            # so it appears exactly once in the MkDocs Material right-hand "On this page"
+            # TOC, with the three time-windows as content tabs *inside* the category.
+            # (The previous period-first layout nested categories as bold text inside
+            # tabs, which produced no TOC entries and tripped MD023 on indented headings.)
+            for cat in categories:
+                # Skip categories with no ranked items in any time window.
+                if not any(digest_data.get(pk, {}).get(cat) for pk in period_labels):
+                    continue
+                md += f"## {cat}\n\n"
+                for period_key, period_label in period_labels.items():
+                    items = digest_data.get(period_key, {}).get(cat, [])
                     if not items:
                         continue
-                    md += f"    **{cat}**\n\n"
+                    md += f'=== "{period_label}"\n\n'
                     md += "    | Date | Resource | Impact | Why It Matters |\n"
                     md += "    | :--- | :--- | :---: | :--- |\n"
                     for item in items:

--- a/v2-docs/industry-digest.md
+++ b/v2-docs/industry-digest.md
@@ -8,16 +8,33 @@ search:
 !!! tip "Nubenetes Intelligence Digest"
     AI-curated ranking of the most impactful resources, updated monthly.
 
-=== "Last 3 Months"
+## Americas
 
-    **Americas**
+=== "Last 3 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
     | 2026-06-02 | [](https://www.ccohs.ca/oshanswers/ergonomics/shovel.html) | 🔵 medium |  |
     | 2026-05-17 | [businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral](https://businessinsider.mx/trucos-chatgpt-aminorar-carga-laboranl_vida-profesional) | 🔵 medium | A curated technical resource and architectural guide covering businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral in the Kubernetes Tools ecosystem. |
 
-    **Europe**
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-02 | [](https://www.ccohs.ca/oshanswers/ergonomics/shovel.html) | 🔵 medium |  |
+    | 2026-05-17 | [businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral](https://businessinsider.mx/trucos-chatgpt-aminorar-carga-laboranl_vida-profesional) | 🔵 medium | A curated technical resource and architectural guide covering businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral in the Kubernetes Tools ecosystem. |
+
+=== "Last 12 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-02 | [](https://www.ccohs.ca/oshanswers/ergonomics/shovel.html) | 🔵 medium |  |
+    | 2026-05-17 | [businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral](https://businessinsider.mx/trucos-chatgpt-aminorar-carga-laboranl_vida-profesional) | 🔵 medium | A curated technical resource and architectural guide covering businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral in the Kubernetes Tools ecosystem. |
+
+
+## Europe
+
+=== "Last 3 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -32,47 +49,7 @@ search:
     | 2026-05-17 | [blog.knell.it: Making your Helm Chart observable for Prometheus](https://blog.knell.it/making-your-helm-chart-observable-for-prometheus) | 🔵 medium | Integrating Prometheus metrics natively into Helm charts ensures observability standards are packaged alongside application deployments by default. |
     | 2026-05-17 | [Templating on OpenShift: should I use Helm templates or OpenShift templates?' 🌟](https://www.padok.fr/en/blog/templating-openshift-helm-templates) | 🔵 medium | It assists enterprise platform engineers in choosing the right templating standard to prevent vendor lock-in while using OpenShift. |
 
-    **Spain**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-05-17 | [aboutamazon.es: AWS acelera la apertura de la Región AWS Europa (España)' para apoyar la transformación digital de España](https://www.aboutamazon.es/innovaci%C3%B3n/aws-acelera-la-apertura-de-la-regi%C3%B3n-aws-europa-espa%C3%B1a-para-apoyar-la-transformaci%C3%B3n-digital-de-espa%C3%B1a) | 🔴 critical | The launch of the AWS Spain region is a massive milestone that addresses data residency and latency requirements, accelerating cloud-native migration for Spanish enterprises. |
-    | 2026-06-01 | [20minutos.es: Amazon Web Services vuelve a romper Internet: se ha caído ya tres veces en el mismo mes y le llueven las críticas](https://www.20minutos.es/tecnologia/actualidad/amazon-web-services-vuelve-a-romper-internet-se-ha-caido-ya-tres-veces-en-el-mismo-mes-y-le-llueven-las-criticas-4931834) | 🟡 high | This analysis of major AWS outages highlights the systemic risks of cloud centralization and underscores the importance of multi-region and multi-cloud resilience strategies. |
-    | 2026-06-14 | [computing.es: Retos del outsourcing de servicios IT en España](https://www.computing.es/mundo-digital/retos-del-outsourcing-de-servicios-it-en-espana) | 🟡 high | It addresses the critical organizational and cultural hurdles of scaling DevSecOps and cloud-native practices when relying on external IT outsourcing in Spain. |
-    | 2026-06-18 | [technologyreview.es: "Las empresas que empiezan a lo grande con la IA fracasan más" 🌟](https://www.technologyreview.es/article/las-empresas-que-empiezan-lo-grande-con-la-ia-fracasan-mas) | 🟡 high | Provides essential strategic guidance for enterprises, arguing for realistic, incremental AI adoption paths rather than high-risk, large-scale overhauls. |
-    | 2026-06-01 | [systemadmin.es](https://systemadmin.es) | 🔵 medium | Provides deep, localized technical knowledge on Linux performance and storage optimization, which are foundational for running high-performance Kubernetes worker nodes. |
-    | 2026-06-01 | [santalucia.es](https://api-market.santalucia.es) | 🔵 medium | Demonstrates a real-world enterprise implementation of API-driven architecture, facilitating digital insurance B2B integrations. |
-    | 2026-06-01 | [Cecabank API Market](https://apimarket.cecabank.es) | 🔵 medium | Showcases production-ready financial API infrastructure designed to comply with PSD2, highlighting modern integration patterns in Spanish banking. |
-    | 2026-05-17 | [softzone.es: Conoce Fleet, el nuevo IDE ultraligero de la mano de JetBrains](https://www.softzone.es/noticias/programas/conoce-fleet-ide-ultraligero-mano-jetbrains) | 🔵 medium | Introduces a lightweight, next-generation IDE that supports remote backend execution, aligning with the cloud-based developer workspace trend. |
-    | 2026-06-02 | [Think Python en espanol (Piensa en Python)](https://libropython.es) | 🔵 medium | Offers a highly accessible, localized resource for mastering Python, which remains a core language for cloud automation, tooling, and AI pipelines. |
-    | 2026-05-17 | [Túneles SSH](https://www.atareao.es/ubuntu/tuneles-ssh) | 🔵 medium | A practical guide to SSH tunneling, a fundamental skill for secure remote access, port forwarding, and network debugging in cloud environments. |
-
-    **Asia-Pacific**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-05-17 | [mixi-developers.mixi.co.jp: Comparing External Secrets Operator with Secret' Storage CSI as Kubernetes External Secrets is Deprecated](https://mixi-developers.mixi.co.jp/compare-eso-with-secret-csi-402bf37f20bc?gi=a7ce4398a8d7) | 🔴 critical | Provides critical architectural guidance for migrating away from the deprecated Kubernetes External Secrets to modern ESO or Secrets Store CSI alternatives. |
-    | 2026-05-17 | [devsecops.co.in: GitOps Guide – What, Why and How? 🌟](https://devsecops.co.in/2021/05/13/gitops-guide-what-why-and-how) | 🟡 high | Demystifies GitOps practices which are essential for achieving declarative, auditable, and automated continuous delivery in cloud-native setups. |
-    | 2026-05-17 | [devstack.in: Deploy Prometheus Operator with Helm3 and Private Registry' 🌟](https://devstack.in/2020/05/25/deploy-prometheus-operator-with-helm3-and-private-registry) | 🟡 high | Addresses a common enterprise security requirement of deploying cloud-native monitoring (Prometheus Operator) within private registry environments. |
-    | 2026-05-17 | [ittroubleshooter.in: Run Parallel Builds in Kubernetes Cluster with Jenkins' Pipeline 🌟](https://ittroubleshooter.in/run-parallel-build-kubernetes-cluster-jenkins) | 🟡 high | Improves CI/CD efficiency by demonstrating how to scale and parallelize build pipelines dynamically using Kubernetes-hosted Jenkins agents. |
-    | 2026-06-01 | [comparecloud.in: Public Cloud Services Comparison 🌟](https://comparecloud.in) | 🔵 medium | Simplifies multi-cloud architecture planning by offering a direct service-mapping taxonomy across major cloud providers. |
-    | 2026-05-17 | [ishantgaurav.in: Kubernetes – Sidecar Container Pattern](https://ishantgaurav.in/2021/07/18/kubernetes-sidecar-container-pattern) | 🔵 medium | Explains the sidecar pattern, which is fundamental to implementing service meshes, logging, and security proxies in microservices. |
-    | 2026-05-17 | [devopstalks.in: Everything about Prometheus](https://devopstalks.in/everything-about-prometheus) | 🔵 medium | Explores Prometheus, the de facto CNCF standard for cloud-native metrics collection and alerting. |
-    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - Taints and Tolerations](https://blog.learncodeonline.in/kubernetes-scheduling-taints-and-tolerations) | 🔵 medium | Covers advanced scheduling techniques necessary for workload isolation and resource allocation in multi-tenant Kubernetes clusters. |
-    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - DaemonSet](https://blog.learncodeonline.in/kubernetes-scheduling-daemonset) | 🔵 medium | Explains DaemonSets, which are vital for running platform-level agents like log forwarders and node monitors. |
-    | 2026-05-17 | [skilledfield.com.au: Monitoring Kubernetes and Docker Container Logs](https://skilledfield.com.au/monitoring-kubernetes-and-docker-container-logs) | 🔵 medium | Provides essential operational foundations for setting up container logging and observability in Kubernetes. |
-
-
 === "Last 6 Months"
-
-    **Americas**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-02 | [](https://www.ccohs.ca/oshanswers/ergonomics/shovel.html) | 🔵 medium |  |
-    | 2026-05-17 | [businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral](https://businessinsider.mx/trucos-chatgpt-aminorar-carga-laboranl_vida-profesional) | 🔵 medium | A curated technical resource and architectural guide covering businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral in the Kubernetes Tools ecosystem. |
-
-    **Europe**
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -87,47 +64,7 @@ search:
     | 2026-05-17 | [en.sokube.ch: K3S + K3D = K8S : a new perfect match for dev and test](https://en.sokube.ch/post/k3s-k3d-k8s-a-new-perfect-match-for-dev-and-test-1) | 🔵 medium | Highlights a highly efficient, lightweight development environment that mirrors production Kubernetes patterns locally. |
     | 2026-05-17 | [Templating on OpenShift: should I use Helm templates or OpenShift templates?' 🌟](https://www.padok.fr/en/blog/templating-openshift-helm-templates) | 🔵 medium | Evaluates configuration management options to help enterprise teams optimize application packaging on Red Hat OpenShift. |
 
-    **Spain**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-05-17 | [aboutamazon.es: AWS acelera la apertura de la Región AWS Europa (España)' para apoyar la transformación digital de España](https://www.aboutamazon.es/innovaci%C3%B3n/aws-acelera-la-apertura-de-la-regi%C3%B3n-aws-europa-espa%C3%B1a-para-apoyar-la-transformaci%C3%B3n-digital-de-espa%C3%B1a) | 🔴 critical | The opening of an AWS Region in Spain provides essential infrastructure for local cloud-native adoption and data residency compliance. |
-    | 2026-06-18 | [technologyreview.es: "Las empresas que empiezan a lo grande con la IA fracasan más" 🌟](https://www.technologyreview.es/article/las-empresas-que-empiezan-lo-grande-con-la-ia-fracasan-mas) | 🟡 high | Provides critical strategic guidance on avoiding common pitfalls in enterprise AI transformation, which is increasingly integrated into cloud-native pipelines. |
-    | 2026-06-01 | [Cecabank API Market](https://apimarket.cecabank.es) | 🟡 high | Demonstrates enterprise-grade API management and security compliance required by the PSD2 mandate in the Spanish financial sector. |
-    | 2026-06-01 | [santalucia.es](https://api-market.santalucia.es) | 🔵 medium | Showcases the shift toward API-first architectures and B2B integration patterns within the traditional insurance sector. |
-    | 2026-06-01 | [systemadmin.es](https://systemadmin.es) | 🔵 medium | Provides foundational knowledge on Linux performance and storage optimization necessary for managing high-performance Kubernetes clusters. |
-    | 2026-05-17 | [softzone.es: Conoce Fleet, el nuevo IDE ultraligero de la mano de JetBrains](https://www.softzone.es/noticias/programas/conoce-fleet-ide-ultraligero-mano-jetbrains) | 🔵 medium | Introduces new developer tooling paradigms that prioritize remote execution and lightweight environments, matching cloud-native development workflows. |
-    | 2026-05-17 | [computing.es: Retos del outsourcing de servicios IT en España](https://www.computing.es/mundo-digital/opinion/1129764046601/retos-del-outsourcing-de-servicios-it-espana.1.html) | 🔵 medium | Addresses the structural challenges of IT outsourcing in Spain, directly impacting how organizations manage cloud-native scaling and DevOps silos. |
-    | 2026-06-02 | [Think Python en espanol (Piensa en Python)](https://libropython.es) | 🔵 medium | Facilitates broader technical literacy in the Spanish community by providing a modern, accessible resource for foundational programming. |
-    | 2026-06-01 | [20minutos.es: Amazon Web Services vuelve a romper Internet: se ha caído ya tres veces en el mismo mes y le llueven las críticas](https://www.20minutos.es/tecnologia/actualidad/amazon-web-services-vuelve-a-romper-internet-se-ha-caido-ya-tres-veces-en-el-mismo-mes-y-le-llueven-las-criticas-4931834) | 🔵 medium | Highlights systemic risks of hyperscaler dependency, prompting necessary architecture discussions around multi-cloud and resilience strategies. |
-    | 2026-05-17 | [hays.es: ‘La Gran Renuncia’: ¿por qué tantos profesionales se están planteando' dejar su trabajo?](https://www.hays.es/blog/insights/la-gran-renuncia) | 🔵 medium | Provides essential context on talent retention and professional shifts in the Spanish IT sector, impacting team stability for cloud-native projects. |
-
-    **Asia-Pacific**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-05-17 | [mixi-developers.mixi.co.jp: Comparing External Secrets Operator with Secret' Storage CSI as Kubernetes External Secrets is Deprecated](https://mixi-developers.mixi.co.jp/compare-eso-with-secret-csi-402bf37f20bc?gi=a7ce4398a8d7) | 🔴 critical | Provides a crucial architectural comparison for managing enterprise secrets securely on Kubernetes following the deprecation of legacy tools. |
-    | 2026-06-01 | [comparecloud.in: Public Cloud Services Comparison 🌟](https://comparecloud.in) | 🟡 high | Simplifies multi-cloud architecture planning by mapping services across major public cloud providers for engineering teams. |
-    | 2026-05-17 | [devstack.in: Deploy Prometheus Operator with Helm3 and Private Registry' 🌟](https://devstack.in/2020/05/25/deploy-prometheus-operator-with-helm3-and-private-registry) | 🟡 high | Delivers a production-ready guide for deploying observability infrastructure securely in enterprise environments using private registries. |
-    | 2026-05-17 | [devsecops.co.in: GitOps Guide – What, Why and How? 🌟](https://devsecops.co.in/2021/05/13/gitops-guide-what-why-and-how) | 🟡 high | Demystifies the GitOps methodology, which is a fundamental paradigm shift for modern cloud-native continuous delivery. |
-    | 2026-05-17 | [ishantgaurav.in: Kubernetes – Sidecar Container Pattern](https://ishantgaurav.in/2021/07/18/kubernetes-sidecar-container-pattern) | 🔵 medium | Explains the sidecar pattern, which is essential for implementing service meshes and platform-level logging in Kubernetes. |
-    | 2026-05-17 | [ittroubleshooter.in: Run Parallel Builds in Kubernetes Cluster with Jenkins' Pipeline 🌟](https://ittroubleshooter.in/run-parallel-build-kubernetes-cluster-jenkins) | 🔵 medium | Optimizes continuous integration pipelines by leveraging Kubernetes to run parallel, dynamically scaled build jobs. |
-    | 2026-05-17 | [devopstalks.in: Everything about Prometheus](https://devopstalks.in/everything-about-prometheus) | 🔵 medium | Offers a comprehensive deep dive into Prometheus, the de facto standard tool for cloud-native system observability. |
-    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - Taints and Tolerations](https://blog.learncodeonline.in/kubernetes-scheduling-taints-and-tolerations) | 🔵 medium | Enables engineers to design resilient and segregated clusters using advanced Kubernetes scheduling constraints. |
-    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - DaemonSet](https://blog.learncodeonline.in/kubernetes-scheduling-daemonset) | 🔵 medium | Details DaemonSet scheduling, which is vital for deploying node-level logging and security agents uniformly across a cluster. |
-    | 2026-05-17 | [skilledfield.com.au: Monitoring Kubernetes and Docker Container Logs](https://skilledfield.com.au/monitoring-kubernetes-and-docker-container-logs) | 🔵 medium | Guides operational teams through establishing essential log aggregation pipelines for containerized applications. |
-
-
 === "Last 12 Months"
-
-    **Americas**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-02 | [](https://www.ccohs.ca/oshanswers/ergonomics/shovel.html) | 🔵 medium |  |
-    | 2026-05-17 | [businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral](https://businessinsider.mx/trucos-chatgpt-aminorar-carga-laboranl_vida-profesional) | 🔵 medium | A curated technical resource and architectural guide covering businessinsider.mx: 5 trucos de ChatGPT que pueden ayudar a reducir tu carga' laboral in the Kubernetes Tools ecosystem. |
-
-    **Europe**
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -142,7 +79,40 @@ search:
     | 2026-05-17 | [blog.knell.it: Making your Helm Chart observable for Prometheus](https://blog.knell.it/making-your-helm-chart-observable-for-prometheus) | 🔵 medium | Establishes a repeatable pattern for embedding native Prometheus observability endpoints directly into reusable Helm charts. |
     | 2026-06-01 | [difftastic.wilfred.me.uk](https://difftastic.wilfred.me.uk) | 🔵 medium | Introduces AST-based syntax comparison that eliminates noisy git diffs, making Kubernetes manifest and code reviews vastly more reliable. |
 
-    **Spain**
+
+## Spain
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-05-17 | [aboutamazon.es: AWS acelera la apertura de la Región AWS Europa (España)' para apoyar la transformación digital de España](https://www.aboutamazon.es/innovaci%C3%B3n/aws-acelera-la-apertura-de-la-regi%C3%B3n-aws-europa-espa%C3%B1a-para-apoyar-la-transformaci%C3%B3n-digital-de-espa%C3%B1a) | 🔴 critical | The launch of the AWS Spain region is a massive milestone that addresses data residency and latency requirements, accelerating cloud-native migration for Spanish enterprises. |
+    | 2026-06-01 | [20minutos.es: Amazon Web Services vuelve a romper Internet: se ha caído ya tres veces en el mismo mes y le llueven las críticas](https://www.20minutos.es/tecnologia/actualidad/amazon-web-services-vuelve-a-romper-internet-se-ha-caido-ya-tres-veces-en-el-mismo-mes-y-le-llueven-las-criticas-4931834) | 🟡 high | This analysis of major AWS outages highlights the systemic risks of cloud centralization and underscores the importance of multi-region and multi-cloud resilience strategies. |
+    | 2026-06-14 | [computing.es: Retos del outsourcing de servicios IT en España](https://www.computing.es/mundo-digital/retos-del-outsourcing-de-servicios-it-en-espana) | 🟡 high | It addresses the critical organizational and cultural hurdles of scaling DevSecOps and cloud-native practices when relying on external IT outsourcing in Spain. |
+    | 2026-06-18 | [technologyreview.es: "Las empresas que empiezan a lo grande con la IA fracasan más" 🌟](https://www.technologyreview.es/article/las-empresas-que-empiezan-lo-grande-con-la-ia-fracasan-mas) | 🟡 high | Provides essential strategic guidance for enterprises, arguing for realistic, incremental AI adoption paths rather than high-risk, large-scale overhauls. |
+    | 2026-06-01 | [systemadmin.es](https://systemadmin.es) | 🔵 medium | Provides deep, localized technical knowledge on Linux performance and storage optimization, which are foundational for running high-performance Kubernetes worker nodes. |
+    | 2026-06-01 | [santalucia.es](https://api-market.santalucia.es) | 🔵 medium | Demonstrates a real-world enterprise implementation of API-driven architecture, facilitating digital insurance B2B integrations. |
+    | 2026-06-01 | [Cecabank API Market](https://apimarket.cecabank.es) | 🔵 medium | Showcases production-ready financial API infrastructure designed to comply with PSD2, highlighting modern integration patterns in Spanish banking. |
+    | 2026-05-17 | [softzone.es: Conoce Fleet, el nuevo IDE ultraligero de la mano de JetBrains](https://www.softzone.es/noticias/programas/conoce-fleet-ide-ultraligero-mano-jetbrains) | 🔵 medium | Introduces a lightweight, next-generation IDE that supports remote backend execution, aligning with the cloud-based developer workspace trend. |
+    | 2026-06-02 | [Think Python en espanol (Piensa en Python)](https://libropython.es) | 🔵 medium | Offers a highly accessible, localized resource for mastering Python, which remains a core language for cloud automation, tooling, and AI pipelines. |
+    | 2026-05-17 | [Túneles SSH](https://www.atareao.es/ubuntu/tuneles-ssh) | 🔵 medium | A practical guide to SSH tunneling, a fundamental skill for secure remote access, port forwarding, and network debugging in cloud environments. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-05-17 | [aboutamazon.es: AWS acelera la apertura de la Región AWS Europa (España)' para apoyar la transformación digital de España](https://www.aboutamazon.es/innovaci%C3%B3n/aws-acelera-la-apertura-de-la-regi%C3%B3n-aws-europa-espa%C3%B1a-para-apoyar-la-transformaci%C3%B3n-digital-de-espa%C3%B1a) | 🔴 critical | The opening of an AWS Region in Spain provides essential infrastructure for local cloud-native adoption and data residency compliance. |
+    | 2026-06-18 | [technologyreview.es: "Las empresas que empiezan a lo grande con la IA fracasan más" 🌟](https://www.technologyreview.es/article/las-empresas-que-empiezan-lo-grande-con-la-ia-fracasan-mas) | 🟡 high | Provides critical strategic guidance on avoiding common pitfalls in enterprise AI transformation, which is increasingly integrated into cloud-native pipelines. |
+    | 2026-06-01 | [Cecabank API Market](https://apimarket.cecabank.es) | 🟡 high | Demonstrates enterprise-grade API management and security compliance required by the PSD2 mandate in the Spanish financial sector. |
+    | 2026-06-01 | [santalucia.es](https://api-market.santalucia.es) | 🔵 medium | Showcases the shift toward API-first architectures and B2B integration patterns within the traditional insurance sector. |
+    | 2026-06-01 | [systemadmin.es](https://systemadmin.es) | 🔵 medium | Provides foundational knowledge on Linux performance and storage optimization necessary for managing high-performance Kubernetes clusters. |
+    | 2026-05-17 | [softzone.es: Conoce Fleet, el nuevo IDE ultraligero de la mano de JetBrains](https://www.softzone.es/noticias/programas/conoce-fleet-ide-ultraligero-mano-jetbrains) | 🔵 medium | Introduces new developer tooling paradigms that prioritize remote execution and lightweight environments, matching cloud-native development workflows. |
+    | 2026-05-17 | [computing.es: Retos del outsourcing de servicios IT en España](https://www.computing.es/mundo-digital/opinion/1129764046601/retos-del-outsourcing-de-servicios-it-espana.1.html) | 🔵 medium | Addresses the structural challenges of IT outsourcing in Spain, directly impacting how organizations manage cloud-native scaling and DevOps silos. |
+    | 2026-06-02 | [Think Python en espanol (Piensa en Python)](https://libropython.es) | 🔵 medium | Facilitates broader technical literacy in the Spanish community by providing a modern, accessible resource for foundational programming. |
+    | 2026-06-01 | [20minutos.es: Amazon Web Services vuelve a romper Internet: se ha caído ya tres veces en el mismo mes y le llueven las críticas](https://www.20minutos.es/tecnologia/actualidad/amazon-web-services-vuelve-a-romper-internet-se-ha-caido-ya-tres-veces-en-el-mismo-mes-y-le-llueven-las-criticas-4931834) | 🔵 medium | Highlights systemic risks of hyperscaler dependency, prompting necessary architecture discussions around multi-cloud and resilience strategies. |
+    | 2026-05-17 | [hays.es: ‘La Gran Renuncia’: ¿por qué tantos profesionales se están planteando' dejar su trabajo?](https://www.hays.es/blog/insights/la-gran-renuncia) | 🔵 medium | Provides essential context on talent retention and professional shifts in the Spanish IT sector, impacting team stability for cloud-native projects. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -157,7 +127,40 @@ search:
     | 2026-06-01 | [santalucia.es](https://api-market.santalucia.es) | 🔵 medium | Demonstrates how legacy enterprises in Spain are modernizing their B2B digital delivery through API-first cloud integration architectures. |
     | 2026-05-17 | [computing.es: Retos del outsourcing de servicios IT en España](https://www.computing.es/mundo-digital/opinion/1129764046601/retos-del-outsourcing-de-servicios-it-espana.1.html) | 🔵 medium | Explores strategic mitigation models for managing SLAs and operational consistency in complex, outsourced enterprise IT environments. |
 
-    **Asia-Pacific**
+
+## Asia-Pacific
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-05-17 | [mixi-developers.mixi.co.jp: Comparing External Secrets Operator with Secret' Storage CSI as Kubernetes External Secrets is Deprecated](https://mixi-developers.mixi.co.jp/compare-eso-with-secret-csi-402bf37f20bc?gi=a7ce4398a8d7) | 🔴 critical | Provides critical architectural guidance for migrating away from the deprecated Kubernetes External Secrets to modern ESO or Secrets Store CSI alternatives. |
+    | 2026-05-17 | [devsecops.co.in: GitOps Guide – What, Why and How? 🌟](https://devsecops.co.in/2021/05/13/gitops-guide-what-why-and-how) | 🟡 high | Demystifies GitOps practices which are essential for achieving declarative, auditable, and automated continuous delivery in cloud-native setups. |
+    | 2026-05-17 | [devstack.in: Deploy Prometheus Operator with Helm3 and Private Registry' 🌟](https://devstack.in/2020/05/25/deploy-prometheus-operator-with-helm3-and-private-registry) | 🟡 high | Addresses a common enterprise security requirement of deploying cloud-native monitoring (Prometheus Operator) within private registry environments. |
+    | 2026-05-17 | [ittroubleshooter.in: Run Parallel Builds in Kubernetes Cluster with Jenkins' Pipeline 🌟](https://ittroubleshooter.in/run-parallel-build-kubernetes-cluster-jenkins) | 🟡 high | Improves CI/CD efficiency by demonstrating how to scale and parallelize build pipelines dynamically using Kubernetes-hosted Jenkins agents. |
+    | 2026-06-01 | [comparecloud.in: Public Cloud Services Comparison 🌟](https://comparecloud.in) | 🔵 medium | Simplifies multi-cloud architecture planning by offering a direct service-mapping taxonomy across major cloud providers. |
+    | 2026-05-17 | [ishantgaurav.in: Kubernetes – Sidecar Container Pattern](https://ishantgaurav.in/2021/07/18/kubernetes-sidecar-container-pattern) | 🔵 medium | Explains the sidecar pattern, which is fundamental to implementing service meshes, logging, and security proxies in microservices. |
+    | 2026-05-17 | [devopstalks.in: Everything about Prometheus](https://devopstalks.in/everything-about-prometheus) | 🔵 medium | Explores Prometheus, the de facto CNCF standard for cloud-native metrics collection and alerting. |
+    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - Taints and Tolerations](https://blog.learncodeonline.in/kubernetes-scheduling-taints-and-tolerations) | 🔵 medium | Covers advanced scheduling techniques necessary for workload isolation and resource allocation in multi-tenant Kubernetes clusters. |
+    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - DaemonSet](https://blog.learncodeonline.in/kubernetes-scheduling-daemonset) | 🔵 medium | Explains DaemonSets, which are vital for running platform-level agents like log forwarders and node monitors. |
+    | 2026-05-17 | [skilledfield.com.au: Monitoring Kubernetes and Docker Container Logs](https://skilledfield.com.au/monitoring-kubernetes-and-docker-container-logs) | 🔵 medium | Provides essential operational foundations for setting up container logging and observability in Kubernetes. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-05-17 | [mixi-developers.mixi.co.jp: Comparing External Secrets Operator with Secret' Storage CSI as Kubernetes External Secrets is Deprecated](https://mixi-developers.mixi.co.jp/compare-eso-with-secret-csi-402bf37f20bc?gi=a7ce4398a8d7) | 🔴 critical | Provides a crucial architectural comparison for managing enterprise secrets securely on Kubernetes following the deprecation of legacy tools. |
+    | 2026-06-01 | [comparecloud.in: Public Cloud Services Comparison 🌟](https://comparecloud.in) | 🟡 high | Simplifies multi-cloud architecture planning by mapping services across major public cloud providers for engineering teams. |
+    | 2026-05-17 | [devstack.in: Deploy Prometheus Operator with Helm3 and Private Registry' 🌟](https://devstack.in/2020/05/25/deploy-prometheus-operator-with-helm3-and-private-registry) | 🟡 high | Delivers a production-ready guide for deploying observability infrastructure securely in enterprise environments using private registries. |
+    | 2026-05-17 | [devsecops.co.in: GitOps Guide – What, Why and How? 🌟](https://devsecops.co.in/2021/05/13/gitops-guide-what-why-and-how) | 🟡 high | Demystifies the GitOps methodology, which is a fundamental paradigm shift for modern cloud-native continuous delivery. |
+    | 2026-05-17 | [ishantgaurav.in: Kubernetes – Sidecar Container Pattern](https://ishantgaurav.in/2021/07/18/kubernetes-sidecar-container-pattern) | 🔵 medium | Explains the sidecar pattern, which is essential for implementing service meshes and platform-level logging in Kubernetes. |
+    | 2026-05-17 | [ittroubleshooter.in: Run Parallel Builds in Kubernetes Cluster with Jenkins' Pipeline 🌟](https://ittroubleshooter.in/run-parallel-build-kubernetes-cluster-jenkins) | 🔵 medium | Optimizes continuous integration pipelines by leveraging Kubernetes to run parallel, dynamically scaled build jobs. |
+    | 2026-05-17 | [devopstalks.in: Everything about Prometheus](https://devopstalks.in/everything-about-prometheus) | 🔵 medium | Offers a comprehensive deep dive into Prometheus, the de facto standard tool for cloud-native system observability. |
+    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - Taints and Tolerations](https://blog.learncodeonline.in/kubernetes-scheduling-taints-and-tolerations) | 🔵 medium | Enables engineers to design resilient and segregated clusters using advanced Kubernetes scheduling constraints. |
+    | 2026-05-17 | [blog.learncodeonline.in: Kubernetes Scheduling - DaemonSet](https://blog.learncodeonline.in/kubernetes-scheduling-daemonset) | 🔵 medium | Details DaemonSet scheduling, which is vital for deploying node-level logging and security agents uniformly across a cluster. |
+    | 2026-05-17 | [skilledfield.com.au: Monitoring Kubernetes and Docker Container Logs](https://skilledfield.com.au/monitoring-kubernetes-and-docker-container-logs) | 🔵 medium | Guides operational teams through establishing essential log aggregation pipelines for containerized applications. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |

--- a/v2-docs/tech-digest.md
+++ b/v2-docs/tech-digest.md
@@ -8,9 +8,9 @@ search:
 !!! tip "Nubenetes Intelligence Digest"
     AI-curated ranking of the most impactful resources, updated monthly.
 
-=== "Last 3 Months"
+## Kubernetes & Orchestration
 
-    **Kubernetes & Orchestration**
+=== "Last 3 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -25,325 +25,7 @@ search:
     | 2026-06-13 | [K9s - Kubernetes CLI To Manage Your Clusters In Style!](https://github.com/derailed/k9s) | 🟡 high | K9s is the ubiquitous, terminal-based CLI dashboard that dramatically accelerates day-to-day cluster navigation and troubleshooting for SREs. |
     | 2026-06-14 | [github.com/helmfile/helmfile](https://github.com/helmfile/helmfile) | 🟡 high | Helmfile provides the necessary declarative wrapper to coordinate, parameterize, and scale complex multi-chart Helm deployments. |
 
-    **Containers & Runtime**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-13 | [containerd - An open and reliable container runtime](https://github.com/containerd/containerd) | 🔴 critical | As the industry-standard container runtime for Kubernetes, containerd is foundational for modern cloud-native container execution. |
-    | 2026-06-13 | [runc](https://github.com/opencontainers/runc) | 🔴 critical | It is the canonical, low-level OCI-compliant container runtime that directly spawns and runs container processes across the industry. |
-    | 2026-06-14 | [buildkit](https://docs.docker.com/build) | 🟡 high | Docker's next-generation build engine fundamentally modernizes image creation through concurrent execution and efficient cache management. |
-    | 2026-06-01 | [podman](https://podman.io) | 🟡 high | Provides a widely adopted daemonless and rootless container engine alternative to Docker, enhancing host security. |
-    | 2026-06-01 | [Dapr](https://dapr.io) | 🟡 high | The Distributed Application Runtime simplifies cloud-native microservices development through its modular sidecar architecture. |
-    | 2026-06-01 | [knative.dev](https://knative.dev) | 🟡 high | Serves as the leading Kubernetes-native framework for deploying and scaling request-driven serverless workloads. |
-    | 2026-05-30 | [crun](https://github.com/containers/crun) | 🟡 high | A high-performance, low-memory C-based alternative to runc that is increasingly adopted for modern container orchestration. |
-    | 2026-06-01 | [buildah](https://buildah.io) | 🟡 high | Allows teams to build OCI-compliant container images without a background daemon, significantly reducing pipeline security risks. |
-    | 2026-06-12 | [**GitHub build-push-action**](https://github.com/docker/build-push-action) | 🟡 high | The de facto standard GitHub Action for orchestrating multi-platform Docker and OCI build-and-push automation. |
-    | 2025-12-15 | [dive 🌟](https://github.com/wagoodman/dive) | 🔵 medium | An indispensable CLI tool that helps engineers inspect container image layers to optimize size and minimize attack surfaces. |
-
-    **Networking & Service Mesh**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-12 | [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api) | 🔴 critical | Establishes the next-generation standard for expressive, role-oriented, and extensible routing and ingress configurations in Kubernetes. |
-    | 2026-06-14 | [github.com: Istio](https://github.com/istio/istio) | 🔴 critical | The leading enterprise-grade service mesh that defines how modern cloud-native architectures secure, control, and observe traffic. |
-    | 2026-06-01 | [Linkerd](https://linkerd.io) | 🔴 critical | The premier Rust-based, CNCF-graduated service mesh that delivers security and performance with minimal operational complexity. |
-    | 2026-05-17 | [github.com/containernetworking 🌟](https://github.com/containernetworking) | 🔴 critical | The foundational specification and reference plugins that underly all modern cloud-native container networking solutions. |
-    | 2026-06-14 | [Envoy Gateway](https://github.com/envoyproxy/gateway) | 🟡 high | Unifies edge proxy management by bringing the official Envoy-backed implementation of the Kubernetes Gateway API. |
-    | 2026-06-02 | [Consul 2.0 improves flexibility, control, and scalability](https://www.hashicorp.com/blog/consul-20-improves-flexibility-control-and-scalability) | 🟡 high | Introduces significant architectural advancements, multi-port service mesh capabilities, and enhanced scale for enterprise service networking. |
-    | 2026-06-14 | [NodeLocal DNSCache](https://github.com/kubernetes/enhancements) | 🟡 high | Significantly improves Kubernetes DNS performance and reliability by running a caching agent on every node to bypass conntrack limits. |
-    | 2026-06-12 | [github.com: kiali](https://github.com/kiali/kiali) | 🟡 high | Provides critical real-time observability, interactive topology mapping, and configuration validation for Istio-based service meshes. |
-    | 2026-06-01 | [Meshery.io:](https://meshery.io) | 🟡 high | Empowers platform engineers to manage, benchmark, and design configurations across diverse service mesh topologies within a unified control plane. |
-    | 2026-06-01 | [editor.cilium.io 🌟](https://editor.networkpolicy.io) | 🔵 medium | Simplifies zero-trust security operations by providing an interactive visual playground to author and debug complex Kubernetes Network Policies. |
-
-    **Architecture & Microservices**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-10 | [Awesome microservices](https://github.com/mfornos/awesome-microservices) | 🔴 critical | A premier comprehensive directory detailing microservices design patterns, API gateways, and distributed consensus engines necessary for building decoupled systems. |
-    | 2026-06-08 | [rootsongjc/awesome-cloud-native 🌟](https://github.com/rootsongjc/awesome-cloud-native) | 🔴 critical | Provides an extensive, systematic mapping of the CNCF landscape, service meshes, and dynamic storage configurations vital for platform architects. |
-    | 2026-06-01 | [developer.hashicorp.com 🌟](https://developer.hashicorp.com) | 🔴 critical | The consolidated technical documentation hub for HashiCorp tools (Terraform, Consul, Vault, Nomad) which define modern multi-cloud infrastructure architectures. |
-    | 2026-05-30 | [clusterpedia-io/clusterpedia 🌟](https://github.com/clusterpedia-io/clusterpedia) | 🟡 high | An innovative open-source search engine that solves multi-cluster discovery issues by synchronizing global Kubernetes resources into a centralized database. |
-    | 2022-11-10 | [Awesome API Management Tools](https://github.com/mailtoharshit/Awesome-Api-Management-Tools) | 🟡 high | A dedicated compilation of API gateway engines and lifecycle management tools crucial for establishing robust, API-first microservices communication patterns. |
-    | 2026-04-25 | [github.com/calvin-puram: Awesome Kubernetes Operator Resources](https://github.com/calvin-puram/awesome-kubernetes-operator-resources) | 🟡 high | A comprehensive index of operator SDKs and controller patterns essential for building self-healing, stateful applications on top of Kubernetes. |
-    | 2026-05-25 | [anderseknert/awesome-opa 🌟](https://github.com/open-policy-agent/awesome-opa) | 🟡 high | Focuses on Open Policy Agent (OPA) integrations, empowering cloud architects to inject declarative security and governance policy-as-code into microservices pipelines. |
-    | 2026-05-23 | [github.com/lukemurraynz/awesome-azure-architecture 🌟](https://github.com/lukemurraynz/awesome-azure-architecture) | 🟡 high | An exhaustive collection of enterprise landing zones and reference architecture designs crucial for bootstrapping highly compliant Azure cloud environments. |
-    | 2026-06-09 | [mingrammer/diagrams](https://github.com/mingrammer/diagrams) | 🔵 medium | An industry-standard Python framework that enables architects to model and version-control complex cloud system topologies directly as code. |
-    | 2026-06-14 | [Terraform Kubernetes Boilerplates 🌟](https://nubenetes.com/terraform) | 🟡 high | Provides pre-tested, production-ready Terraform templates to quickly bootstrap secure network topologies and managed Kubernetes services across major cloud providers. |
-
-    **Data, Messaging & Storage**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [strimzi.io](https://strimzi.io) | 🔴 critical | The premier CNCF-backed project that makes running and managing production Apache Kafka clusters on Kubernetes seamless via the Operator pattern. |
-    | 2026-06-12 | [github.com/vmware-tanzu/velero](https://github.com/velero-io/velero) | 🔴 critical | The industry-standard open-source solution for Kubernetes disaster recovery, backing up both cluster state and persistent volume data. |
-    | 2026-06-01 | [Longhorn](https://longhorn.io) | 🔴 critical | A graduated CNCF project offering highly reliable, distributed block storage built natively and lightweight for Kubernetes environments. |
-    | 2026-06-01 | [min.io](https://www.min.io) | 🔴 critical | The leading S3-compatible high-performance object storage platform designed specifically for Kubernetes and private cloud deployments. |
-    | 2026-06-01 | [**Debezium**:](https://debezium.io) | 🟡 high | The de facto standard for log-based Change Data Capture (CDC), enabling real-time database streaming in modern event-driven architectures. |
-    | 2026-06-01 | [Apache Flink](https://flink.apache.org) | 🟡 high | The industry-standard framework for high-throughput, stateful stream processing on real-time event logs with robust exactly-once guarantees. |
-    | 2026-06-01 | [Redpanda 🌟](https://www.redpanda.com) | 🟡 high | A highly innovative, JVM-free Kafka alternative written in C++ that significantly reduces infrastructure footprint and operational complexity. |
-    | 2026-06-12 | [Zalando Postgres Operator](https://github.com/zalando/postgres-operator) | 🟡 high | An enterprise-grade, production-proven operator that automates the deployment and high-availability management of PostgreSQL on Kubernetes. |
-    | 2026-06-01 | [OpenEBS](https://openebs.io) | 🟡 high | A prominent Container Attached Storage (CAS) platform that simplifies turning local disks into dynamic persistent volumes for stateful applications. |
-    | 2026-06-14 | [github.com/kubernetes-sigs: Local Persistence Volume Static Provisioner' 🌟](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) | 🟡 high | An official Kubernetes-SIG project that automates local storage provisioning, enabling latency-sensitive databases to achieve maximum raw NVMe performance. |
-
-    **AI & Agents**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-18 | [antigravity.google: Google Antigravity Agentic Platform](https://antigravity.google) | 🔴 critical | It directly bridges the gap between local agent prototypes and production-grade Google Kubernetes Engine (GKE) deployments for stateful AI agents. |
-    | 2026-06-14 | [vLLM on Kubernetes](https://github.com/vllm-project/vllm) | 🔴 critical | It provides the definitive standard for hosting highly optimized, memory-efficient LLM serving engines using PagedAttention on Kubernetes. |
-    | 2026-06-18 | [docs.anthropic.com: Claude Code CLI](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | 🔴 critical | Anthropic's official tool fundamentally shifts developer workflows by bringing autonomous agentic coding and execution directly into the terminal. |
-    | 2026-06-02 | [Announcing Claude Managed Agents on Cloudflare](https://blog.cloudflare.com/claude-managed-agents) | 🟡 high | It establishes a secure, cloud-native sandboxed execution plane for running autonomous AI agents on serverless edge infrastructure. |
-    | 2026-06-07 | [GitHub MCP Server](https://github.com/modelcontextprotocol/servers) | 🟡 high | It standardizes the Model Context Protocol (MCP) to enable secure, structured communication and tool usage for AI agents across different host environments. |
-    | 2026-06-13 | [LocalAI](https://github.com/mudler/LocalAI) | 🟡 high | It enables secure, private, and fully self-hosted deployments of OpenAI-compatible LLM APIs and agent backends on local and Kubernetes infrastructure. |
-    | 2026-06-18 | [cursor.com: Cursor AI Code Editor](https://cursor.com) | 🟡 high | It is the premier AI-first IDE driving widespread developer adoption of multi-file agentic code generation and editor workflows. |
-    | 2026-06-10 | [Google Agents CLI](https://github.com/google/agents-cli) | 🟡 high | An official command-line interface from Google that leverages MCP and Gemini models to orchestrate automated, agentic tasks. |
-    | 2026-06-02 | [OpenAI and Dell Technologies partner to bring Codex to hybrid and on-premises enterprise environments](https://openai.com/index/dell-codex-enterprise-partnership) | 🟡 high | It accelerates enterprise adoption of advanced coding agents by bridging OpenAI's developer ecosystem with on-premises and hybrid cloud environments. |
-    | 2026-06-14 | [OpenOps: No-Code FinOps Automation Platform with AI](https://github.com/openops-cloud/openops) | 🔵 medium | It directly connects Kubernetes metric endpoints with AI optimization to automate cloud cost reductions and sizing adjustments. |
-
-    **MLOps & Data Science**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Ray](https://docs.ray.io/en/latest) | 🔴 critical | Ray is the industry-standard distributed compute framework essential for scaling heavy AI training and LLM workloads. |
-    | 2026-05-17 | [openai.com: Scaling Kubernetes to 7,500 nodes 🌟](https://openai.com/research/scaling-kubernetes-to-7500-nodes) | 🔴 critical | OpenAI's scaling insights provide the ultimate blueprint for running massive-scale machine learning workloads on Kubernetes. |
-    | 2026-06-13 | [github.com/Netflix/metaflow 🌟](https://github.com/Netflix/metaflow) | 🟡 high | Metaflow bridges the gap between local data science development and scalable cloud-native production infrastructure. |
-    | 2026-05-19 | [github.com/meta-llama/llama-recipes](https://github.com/meta-llama/llama-cookbook) | 🟡 high | Meta's official recipes establish standardized best practices for parameter-efficient fine-tuning and LLM optimization. |
-    | 2026-06-08 | [rubrix](https://github.com/argilla-io/argilla) | 🟡 high | Argilla addresses the critical LLM challenge of data curation and continuous human-in-the-loop alignment. |
-    | 2026-06-02 | [SilverTorch: Index as Model — A New Retrieval Paradigm for Recommendation Systems](https://engineering.fb.com/2026/05/26/ml-applications/silvertorch-index-as-model-new-retrieval-paradigm-recommendation-systems) | 🟡 high | SilverTorch redefines recommendation engine architectures by unifying retrieval and scoring into a single GPU-optimized model. |
-    | 2026-06-18 | [mikeroyal/Kubernetes-Guide: Machine Learning 🌟](https://github.com/mikeroyal/Kubernetes-Guide/blob/main/README.md) | 🟡 high | This manual serves as an indispensable reference mapping the complex landscape of running machine learning workloads on Kubernetes. |
-    | 2026-05-17 | [medium.com/workday-engineering: Implementing a Fully Automated Sharding' Strategy on Kubernetes for Multi-tenanted Machine Learning Applications](https://medium.com/workday-engineering/implementing-a-fully-automated-sharding-strategy-on-kubernetes-for-multi-tenanted-machine-learning-4371c48122ae) | 🟡 high | It outlines a highly sophisticated, real-world architectural pattern for managing multi-tenant ML applications using Kubernetes sharding. |
-    | 2026-05-17 | [medium.com/@bchenjh: Distributed full fine-tuning of Llama2 on Kubernetes](https://medium.com/@bchenjh/full-fine-tuning-of-llama2-on-kubernetes-a983e1eb2259) | 🟡 high | This guide provides a practical, cloud-native blueprint for running distributed LLM fine-tuning operations on Kubernetes. |
-    | 2026-05-21 | [tensorchord/envd: Reproducible development environment for AI/ML 🌟](https://github.com/tensorchord/envd) | 🔵 medium | Envd solves the notorious ML pain point of environment reproducibility by generating isolated, CUDA-ready dev containers from Python declarations. |
-
-    **Python, Java & Developer Ecosystem**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [metalbear-co/mirrord](https://github.com/metalbear-co/mirrord) | 🔴 critical | Plugs local processes directly into remote Kubernetes namespaces to streamline local development without remote deployments. |
-    | 2026-06-14 | [Ruff](https://github.com/astral-sh/ruff) | 🟡 high | Revolutionizes Python development by providing an extremely fast, Rust-powered linter and formatter that dramatically reduces CI loop times. |
-    | 2026-06-14 | [testcontainers-spring-boot 🌟](https://github.com/PlaytikaOSS/testcontainers-spring-boot) | 🟡 high | Streamlines Java integration testing by automatically managing Docker container lifecycles directly within JUnit executions. |
-    | 2026-06-13 | [github.com/spring-projects: springboot enables these probes automatically when running in k8s](https://github.com/spring-projects/spring-boot#L73) | 🟡 high | Automatically integrates Spring Boot applications with Kubernetes by auto-detecting hosting environments and configuring Liveness/Readiness probes. |
-    | 2026-06-13 | [pydantic/pydantic](https://github.com/pydantic/pydantic) | 🟡 high | Delivers ultra-fast, Rust-backed type validation that has become the de facto standard for building robust Python services. |
-    | 2026-06-12 | [apache/maven-mvnd](https://github.com/apache/maven-mvnd) | 🟡 high | Drastically reduces Java compilation times using a persistent background build daemon to cache hot-spots and configurations. |
-    | 2026-06-12 | [github: Spring Cloud Kubernetes 🌟](https://github.com/spring-cloud/spring-cloud-kubernetes) | 🟡 high | Enables Spring Cloud applications to natively discover and interact with Kubernetes platform features like ConfigMaps, Secrets, and services. |
-    | 2026-06-12 | [github.com/bloomberg/memray 🌟🌟](https://github.com/bloomberg/memray) | 🟡 high | Provides an advanced memory profiler for Python microservices to track allocations and resolve performance bottlenecks. |
-    | 2026-06-01 | [quarkus.io](https://quarkus.io) | 🔴 critical | Optimizes Java for Kubernetes and serverless environments by offering lightning-fast startup times and low memory footprints via GraalVM. |
-    | 2026-05-17 | [Kubernetes (by Microsoft)](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) | 🟡 high | Acts as the definitive visual tool for cloud-native developers to manage clusters and debug microservices directly from VS Code. |
-
-    **Linux & System Foundations**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [redhat.com: World domination with cgroups part 8: down and dirty with cgroup v2](https://www.redhat.com/en/blog/world-domination-cgroups-part-8-down-and-dirty-cgroup-v2) | 🔴 critical | Directly impacts container and Kubernetes node resource isolation by detailing cgroup v2 mechanics and Memory Pressure Stalls (PSI). |
-    | 2026-06-13 | [bpftrace](https://github.com/bpftrace/bpftrace) | 🟡 high | Provides a high-level tracing language leveraging eBPF, revolutionizing modern system diagnostics and kernel-level performance debugging. |
-    | 2026-06-01 | [LWN.net](https://lwn.net) | 🟡 high | Remains the gold standard for tracking upstream Linux kernel evolution and structural operating system paradigms essential for platform engineering. |
-    | 2024-04-30 | [termshark](https://github.com/gcla/termshark) | 🟡 high | Enables interactive, terminal-based network packet analysis on headless servers and Kubernetes nodes over remote SSH connections. |
-    | 2026-03-05 | [How-To Secure A Linux Server](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server) | 🟡 high | Provides an actionable, step-by-step framework for securing and hardening enterprise-grade Linux servers against modern threats. |
-    | 2026-06-01 | [abarrak.gitbook.io: Linux SysOps Handbook 🌟](https://abarrak.gitbook.io/linux-sysops-handbook) | 🟡 high | Acts as an essential, high-density operational handbook for on-call systems engineers diagnosing complex performance and networking issues. |
-    | 2026-01-05 | [github: Safe ways to do things in bash](https://github.com/anordal/shellharden/blob/master/how_to_do_things_safely_in_bash.md) | 🟡 high | Serves as an authoritative style manual to prevent common script failures, scoping bugs, and safety issues in systems automation. |
-    | 2026-06-01 | [sysadminxpert.com: How to watch real time TCP and UDP ports on Linux (netstat & ss) 🌟](https://sysadminxpert.com/how-to-watch-real-time-tcp-and-udp-ports-on-linux) | 🔵 medium | Compares key low-level diagnostic tools vital for verifying active port binds, ingress routing, and socket states on Linux hosts. |
-    | 2026-06-01 | [**curl command**: Understanding the Hidden Powers of curl](https://nordicapis.com/understanding-the-hidden-powers-of-curl) | 🔵 medium | Deepens technical understanding of curl for raw TCP manipulation and custom HTTP requests, which is crucial for cloud-native API troubleshooting. |
-    | 2026-05-31 | [oilshell: Alternative shells](https://github.com/oils-for-unix/oils/wiki/Alternative-Shells) | 🔵 medium | Evaluates next-generation shells that attempt to replace legacy bash with safer parsing, structured JSON pipelines, and robust error handling. |
-
-    **Security & Compliance**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [Tetragon (Cilium)](https://github.com/cilium/tetragon) | 🔴 critical | eBPF-powered security observability at the kernel level represents a paradigm shift for Kubernetes runtime enforcement. |
-    | 2026-06-12 | [hashicorp/vault](https://github.com/hashicorp/vault) | 🔴 critical | It remains the absolute backbone of enterprise Zero Trust architectures and dynamic secrets management across multi-cloud environments. |
-    | 2026-05-17 | [OPA Open Policy Agent 🌟](https://www.openpolicyagent.org) | 🔴 critical | As a CNCF graduated project, OPA defines the industry standard for decoupling policy-as-code from core application logic. |
-    | 2026-06-18 | [Project Calico 🌟](https://www.tigera.io/project-calico) | 🔴 critical | Calico is an industry-standard networking and security engine enabling high-performance eBPF container network interface enforcement. |
-    | 2026-06-11 | [trivy](https://github.com/aquasecurity/trivy) | 🟡 high | Aqua Security's scanner is the dominant tool for container and IaC vulnerability detection within modern CI/CD pipelines. |
-    | 2026-06-13 | [github.com/prowler-cloud/prowler 🌟🌟](https://github.com/prowler-cloud/prowler) | 🟡 high | Prowler is the de facto open-source tool for auditing multi-cloud security posture and compliance against rigorous benchmarks. |
-    | 2026-06-01 | [keycloak.org](https://www.keycloak.org) | 🟡 high | Keycloak stands as the industry-standard open-source identity and access management platform with native cloud integration. |
-    | 2026-05-17 | [checkov.io](https://www.checkov.io) | 🟡 high | It provides dominant static analysis capability for detecting security misconfigurations across infrastructure-as-code files. |
-    | 2026-06-13 | [sops: Simple and flexible tool for managing secrets 🌟](https://github.com/getsops/sops) | 🟡 high | SOPS is the essential, industry-trusted utility for managing file-level secrets within declarative GitOps workflows. |
-    | 2026-06-12 | [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator) | 🟡 high | An official Kubernetes SIG project that simplifies and automates the enforcement of host-level Seccomp and AppArmor profiles. |
-
-    **Infrastructure as Code**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-02 | [OpenTofu 1.12: the Feature Terraform Never Shipped](https://www.infoq.com/news/2026/05/opentofu-release-terraform) | 🔴 critical | OpenTofu 1.12 solves a major historical limitation of upstream Terraform by introducing dynamic, modular configurations, representing a significant milestone for the open-source fork. |
-    | 2026-06-02 | [The Agentic Infrastructure Era \| Pulumi Releases](https://www.pulumi.com/releases/agentic-infrastructure-era) | 🔴 critical | This release marks a fundamental paradigm shift in cloud engineering toward autonomous, agent-driven infrastructure provisioning and self-healing environments. |
-    | 2026-06-02 | [New in Terraform 1.15: Dynamic sources, variable deprecation, and more](https://www.hashicorp.com/en/blog/new-in-terraform-115-dynamic-sources-variable-deprecation-and-more) | 🟡 high | The introduction of native dynamic module sources and version parsing in Terraform 1.15 directly improves how enterprises manage and inject variable configurations into upstream dependencies. |
-    | 2026-05-29 | [github.com/terraform-aws-modules/terraform-aws-eks: AWS EKS Terraform module](https://github.com/terraform-aws-modules/terraform-aws-eks) | 🟡 high | As the industry-standard module for deploying AWS EKS, this resource remains a critical foundational component for cloud-native Kubernetes infrastructure. |
-    | 2026-06-02 | [Neo, Now in the Terminal \| Pulumi Blog](https://www.pulumi.com/blog/pulumi-neo-cli) | 🟡 high | Bringing the Neo AI assistant directly into the terminal interface introduces a highly novel, agentic UX for local infrastructure generation and debugging. |
-    | 2026-06-09 | [github.com/microsoft/terraform-provider-azuredevops/releases/tag/v1.0.0](https://github.com/microsoft/terraform-provider-azuredevops/releases/tag/v1.0.0) | 🟡 high | Reaching GA v1.0.0 establishes critical production-readiness for enterprises looking to fully govern their Azure DevOps platforms through declarative IaC. |
-    | 2026-06-03 | [Infracost 🌟](https://github.com/infracost/infracost) | 🟡 high | This tool enables proactive FinOps governance by parsing HCL files to output precise cloud cost projections before infrastructure changes are applied. |
-    | 2026-03-05 | [Kubestack Gitops Framework](https://github.com/kbst/terraform-kubestack) | 🟡 high | A specialized GitOps framework that natively leverages Terraform's configuration inheritance to streamline multi-cluster Kubernetes platform deployments. |
-    | 2026-05-27 | [mineiros-io/terramate](https://github.com/terramate-io/terramate) | 🟡 high | Terramate optimizes modern platform engineering operations by solving code duplication and change-detection bottlenecks within large-scale multi-directory IaC monorepos. |
-    | 2026-06-10 | [AWX Operator](https://github.com/ansible/awx-operator) | 🔵 medium | The AWX Operator brings legacy automation frameworks into the cloud-native era by orchestrating the AWX lifecycle using native Kubernetes Custom Resource Definitions. |
-
-    **CI/CD & GitOps**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Argo CD](https://argoproj.github.io/argo-cd) | 🔴 critical | As the industry standard for GitOps-based continuous delivery, Argo CD is vital for synchronizing live Kubernetes cluster states with declarative Git configurations. |
-    | 2026-06-13 | [github: Flux Version 2](https://github.com/fluxcd/flux2) | 🔴 critical | Flux v2 is a foundational CNCF graduated project that implements a highly parallelized, modular GitOps controller architecture for enterprise-grade reconciliation. |
-    | 2026-06-14 | [dagger/dagger: Dagger is a portable devkit for CICD](https://github.com/dagger/dagger) | 🔴 critical | Dagger represents a major paradigm shift in CI/CD by replacing brittle YAML pipelines with portable, code-driven workflows executed on BuildKit. |
-    | 2026-06-14 | [github: Tekton Pipelines](https://github.com/tektoncd/pipeline) | 🟡 high | Tekton Pipelines provides the definitive Kubernetes-native CI engine using custom resource definitions to run modular, containerized build steps. |
-    | 2026-06-08 | [github.com/flux-iac/tofu-controller](https://github.com/flux-iac/tofu-controller) | 🟡 high | The tofu-controller natively brings GitOps principles to OpenTofu and Terraform, standardizing infrastructure-as-code execution within Kubernetes control planes. |
-    | 2026-06-14 | [Helm](https://nubenetes.com/helm) | 🟡 high | Helm remains the indispensable package manager for Kubernetes, defining how cloud-native applications are structured, versioned, and shared across environments. |
-    | 2026-06-14 | [Keptn](https://nubenetes.com/keptn) | 🟡 high | Keptn bridges continuous delivery and operations by orchestrating SLO-based quality gates and automated canary promotions using cloud-native control planes. |
-    | 2026-06-14 | [feat(ui): Add AppSet to Application Resource Tree in Argo CD](https://github.com/argoproj/argo-cd/pull/26601) | 🟡 high | Integrating ApplicationSets directly into the Argo CD UI greatly simplifies the observability and visualization of complex, multi-tenant GitOps topologies. |
-    | 2026-06-08 | [kubernetes-plugin: Kubernetes plugin for Jenkins 🌟](https://github.com/jenkinsci/kubernetes-plugin) | 🟡 high | This plugin is critical for hybrid enterprises modernizing legacy workloads, allowing Jenkins to dynamically scale isolated executor pods directly on Kubernetes. |
-    | 2026-06-14 | [github.com/glasskube/glasskube](https://github.com/glasskube/glasskube) | 🟡 high | Glasskube introduces a next-generation package manager for Kubernetes, significantly improving package discovery, automated updates, and dependency management. |
-
-    **Observability, SRE & Testing**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-12 | [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) | 🔴 critical | Acts as the industry-standard, vendor-agnostic pipeline for receiving, processing, and routing metrics, logs, and traces across diverse cloud-native environments. |
-    | 2026-06-13 | [github.com/prometheus/prometheus](https://github.com/prometheus/prometheus) | 🔴 critical | Serves as the foundational, de-facto standard metrics database and query engine powering the entire cloud-native observability ecosystem. |
-    | 2026-05-17 | [github.com/prometheus-operator](https://github.com/prometheus-operator) | 🔴 critical | Pioneered the operator pattern to fully automate the deployment, configuration, and scaling of Prometheus instances in Kubernetes. |
-    | 2026-06-14 | [kube-state-metrics 🌟](https://github.com/kubernetes/kube-state-metrics) | 🔴 critical | Essential cluster service that translates internal Kubernetes API resources into Prometheus metrics for accurate, real-time infrastructure state analysis. |
-    | 2026-06-13 | [Grafana Tempo](https://github.com/grafana/tempo) | 🟡 high | Redefines distributed tracing scalability by using cost-effective object storage to manage massive volumes of enterprise trace data without massive storage bills. |
-    | 2026-06-13 | [github.com/open-telemetry/opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-operator) | 🟡 high | Simplifies enterprise telemetry adoption by automating zero-code application instrumentation and collector management inside Kubernetes. |
-    | 2026-06-12 | [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) | 🟡 high | Serves as the gold-standard reference monitoring stack, combining critical observability components for immediate out-of-the-box cluster visibility. |
-    | 2026-06-12 | [Chaos Mesh](https://github.com/chaos-mesh/chaos-mesh) | 🟡 high | Provides a robust, CNCF-incubating platform to seamlessly orchestrate chaos engineering experiments directly inside cloud-native topologies. |
-    | 2026-06-14 | [github.com/grafana/mimir](https://github.com/grafana/mimir) | 🟡 high | Delivers production-ready, horizontally-scalable, and multi-tenant long-term metrics storage designed for high-volume enterprise workloads. |
-    | 2026-06-14 | [grafana.com: How to manage high cardinality metrics in Prometheus and Kubernetes](https://grafana.com/blog/how-to-manage-high-cardinality-metrics-in-prometheus-and-kubernetes) | 🟡 high | Addresses high cardinality, the most prominent operational and financial pain point in cloud-native monitoring, with proven optimization techniques. |
-
-    **DevOps & Culture**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-13 | [github.com/backstage/backstage](https://github.com/backstage/backstage) | 🔴 critical | Backstage is the industry-standard CNCF framework for building internal developer portals, drastically reducing cognitive load for platform engineering teams. |
-    | 2026-06-12 | [Azure DevOps MCP Server](https://github.com/microsoft/azure-devops-mcp) | 🟡 high | It bridges AI agents with enterprise CI/CD environments, enabling agentic orchestration and automated management of Azure DevOps workflows. |
-    | 2026-06-10 | [Devtron](https://github.com/devtron-labs/devtron) | 🟡 high | Devtron simplifies Kubernetes AppOps by consolidating GitOps, CI/CD, and multi-cluster observability into a unified self-service platform. |
-    | 2026-06-14 | [blog.postman.com: What Is PlatformOps?](https://blog.postman.com/what-is-platformops) | 🟡 high | This article defines the rise of PlatformOps as the operational engine behind Platform Engineering, marking a crucial evolution in cloud-native organizational structures. |
-    | 2026-05-29 | [action-tmate: Debug GitHub Actions via SSH](https://github.com/mxschmitt/action-tmate) | 🟡 high | An invaluable interactive debugging utility that significantly accelerates pipeline troubleshooting by opening secure SSH connections into live GitHub Actions runs. |
-    | 2026-06-14 | [IaC Infrastructure as Code](https://nubenetes.com/iac) | 🟡 high | An essential cloud-native architectural guide outlining the modern philosophies, lifecycles, and state management of Infrastructure as Code. |
-    | 2026-06-14 | [NoOps](https://nubenetes.com/noops) | 🟡 high | Provides a strategic roadmap for the transition to NoOps, highlighting how teams can outsource operational overhead using automated serverless paradigms. |
-    | 2026-06-02 | [Introducing Cursor in Jira - Inside Atlassian](https://www.atlassian.com/blog/company-news/cursor-in-jira) | 🟡 high | Integrates cutting-edge AI development tools with standard agile tracking, bridging the gap between automated code generation and project management workflows. |
-    | 2026-06-14 | [DevOps Tools](https://nubenetes.com/devops-tools) | 🔵 medium | Offers a comprehensive mapping of modern DevOps tooling to build and scale stable, automated production delivery pipelines. |
-    | 2026-06-14 | [blog.vmware.com: DevOps: Culture – Collaboration, Empowerment, Autonomy 🌟](https://blogs.vmware.com/cloud-foundation) | 🔵 medium | Highlights the critical organizational and cultural transformations, such as psychological safety and autonomy, required to sustain successful DevOps practices. |
-
-    **Platform Engineering & DevEx**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Backstage Developer Portal:](https://backstage.io) | 🔴 critical | As a CNCF-graduated project, it is the de facto open-source framework for building internal developer portals to centralize platform tooling. |
-    | 2026-06-11 | [Azure/Draft 🌟](https://github.com/Azure/draft) | 🔴 critical | Significantly reduces Kubernetes onboarding friction by automatically generating containerization assets and deployment manifests directly from source code. |
-    | 2026-06-01 | [Kong API Manager](https://konghq.com/products/kong-gateway) | 🟡 high | A highly customizable and widely adopted lightweight API gateway that serves as a cornerstone for cloud-native microservices routing. |
-    | 2026-06-12 | [apisix](https://github.com/apache/apisix) | 🟡 high | A high-performance Apache-backed cloud-native API gateway that offers dynamic routing and active health checking for large-scale platforms. |
-    | 2026-06-01 | [docs.traefik.io](https://doc.traefik.io/traefik) | 🟡 high | An industry-standard cloud-native edge router and ingress controller that simplifies dynamic configuration and routing in Kubernetes. |
-    | 2026-06-01 | [KrakenD: The fastest API gateway comes with true linear scalability 🌟](https://www.krakend.io) | 🟡 high | Delivers an ultra-high performance, stateless API gateway engine designed to scale linearly without the overhead of central databases. |
-    | 2026-06-01 | [Material for MkDocs](https://squidfunk.github.io/mkdocs-material) | 🔵 medium | Serves as the industry-standard UI layout for engineering documentation, dramatically improving the developer experience through clean, navigable guides. |
-    | 2026-06-01 | [Tyk API Manager](https://tyk.io) | 🔵 medium | A powerful Go-based gateway that offers exceptional clustering and dynamic rate limiting to robustly scale cloud-native platforms. |
-    | 2026-06-01 | [Red Hat 3scale API Management](https://www.redhat.com/en/technologies/jboss-middleware/3scale) | 🔵 medium | Provides an operator-driven, containerized API management solution optimized for enterprise Red Hat OpenShift environments. |
-    | 2026-06-01 | [Spring Cloud Gateway](https://spring.io/projects/spring-cloud-gateway) | 🔵 medium | An essential reactive routing gateway that bridges the gap between enterprise Java developers and cloud-native microservice architectures. |
-
-    **FinOps & Cloud Cost**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [FinOps Foundation: FinOps.org](https://www.finops.org) | 🔴 critical | Serves as the foundational, Linux Foundation-backed industry standard defining FinOps practices, frameworks, and open billing data specifications like FOCUS. |
-    | 2026-05-17 | [cast.ai: Keep your AWS Kubernetes costs in check with intelligent allocation' (EKS)](https://cast.ai/blog/keep-your-aws-kubernetes-costs-in-check-with-intelligent-allocation) | 🟡 high | Demonstrates automated container resource provisioning and dynamic node allocation to prevent cost-heavy over-provisioning in EKS environments. |
-    | 2026-06-18 | [cncf.io: FinOps for Kubernetes: Insufficient – or nonexistent – Kubernetes' cost monitoring is causing overspend](https://www.cncf.io/blog/2021/06/29/finops-for-kubernetes-insufficient-or-nonexistent-kubernetes-cost-monitoring-is-causing-overspend) | 🟡 high | Provides a vital CNCF community perspective highlighting how inadequate Kubernetes cost visibility directly leads to runaway cloud spend. |
-    | 2026-04-09 | [Cloudburn: An Open-Source Policy Engine for AWS Spending](https://github.com/towardsthecloud/cloudburn) | 🟡 high | Introduces an open-source, declarative policy engine that allows platform teams to programmatically audit and restrict idle AWS infrastructure. |
-    | 2026-05-17 | [engineering.razorpay.com: The Culture of Cost Optimization — Reducing Kubernetes' cost by $300,000](https://engineering.razorpay.com/the-culture-of-cost-optimization-reducing-kubernetes-cost-by-300-000-32611cdd19d9) | 🟡 high | Shares concrete, production-scale engineering strategies that successfully shaved $300,000 off a high-volume Kubernetes cluster's operational costs. |
-    | 2026-05-17 | [Visualize and gain insights into your AWS cost and usage with Cloud Intelligence Dashboards and CUDOS using Amazon QuickSight](https://aws.amazon.com/blogs/mt/visualize-and-gain-insights-into-your-aws-cost-and-usage-with-cloud-intelligence-dashboards-using-amazon-quicksight) | 🟡 high | Delivers an enterprise-grade blueprint for building robust, real-time billing visualizations and anomaly detection using AWS CUDOS and QuickSight. |
-    | 2026-05-17 | [medium.com/develeap: Cutting down Kubernetes Costs: Cast.ai vs. Karpenter](https://medium.com/develeap/cutting-down-kubernetes-costs-cast-ai-vs-karpenter-20f6788b4c67) | 🔵 medium | Presents a crucial technical evaluation between two leading Kubernetes autoscaling and cost-optimization technologies, Karpenter and Cast.ai. |
-    | 2026-05-17 | [medium.com/@danielepolencic: In Kubernetes, are there hidden costs to' running many cluster nodes?](https://medium.com/@danielepolencic/reserved-cpu-and-memory-in-kubernetes-nodes-65aee1946afd) | 🔵 medium | Unpacks the critical system-level CPU and memory reservation overheads that act as hidden cost drivers when scaling up Kubernetes nodes. |
-    | 2026-06-18 | [learnk8s/xlskubectl](https://github.com/learnk8s/xlskubectl) | 🔵 medium | Bridges the gap between engineering CLI outputs and financial analysis by dynamically exporting Kubernetes resource metrics into interactive spreadsheets. |
-    | 2026-05-18 | [Announcing General Availability of AWS Cost Anomaly Detection](https://aws.amazon.com/blogs/aws-cloud-financial-management/announcing-general-availability-of-aws-cost-anomaly-detection) | 🟡 high | Offers native, machine-learning-driven spend anomaly detection to proactively flag and prevent runaway cloud billing events before they escalate. |
-
-    **Certification & Training**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [The Linux Foundation Training](https://training.linuxfoundation.org/resources) | 🔴 critical | The definitive training home of the Linux Foundation, serving as the official curriculum and exam administrator for CKA, CKAD, and CKS. |
-    | 2026-06-01 | [kubernetes.io 🌟](https://kubernetes.io/docs/reference/kubectl/quick-reference) | 🔴 critical | The ultimate kubectl quick reference and the only canonical documentation permitted for live lookup during Kubernetes certification exams. |
-    | 2026-06-01 | [Whizlabs](https://www.whizlabs.com) | 🟡 high | Provides highly sought-after practice simulations and sandbox environments explicitly mapped to cloud-native certifications like CKA and CKS. |
-    | 2026-06-01 | [kube.academy](https://kube.academy) | 🟡 high | An outstanding, structured platform sponsored by VMware Tanzu that delivers highly technical, modular tracks for Kubernetes cluster operators. |
-    | 2026-06-01 | [edx.org](https://www.edx.org) | 🟡 high | Hosts the official Linux Foundation training catalog, delivering foundational to advanced university-grade cloud-native education. |
-    | 2026-06-08 | [stefanprodan/podinfo](https://github.com/stefanprodan/podinfo) | 🟡 high | The standard reference application used globally to teach and demonstrate Kubernetes orchestration, health checking, and progressive delivery. |
-    | 2026-06-18 | [techiescamp/devops-projects:Real-World DevOps Projects For Learning](https://github.com/techiescamp/devops-projects) | 🟡 high | A comprehensive hands-on library of real-world DevOps projects providing direct, template-based learning for CI/CD and infrastructure-as-code. |
-    | 2026-06-01 | [techstudyslack.com](https://techstudyslack.com) | 🔵 medium | An active peer community offering specialized debugging support and study guides tailored for passing Kubernetes certifications. |
-    | 2026-06-18 | [github.com/devoriales/kubectl-cheatsheet](https://github.com/devoriales/cheatsheets) | 🔵 medium | An opinionated kubectl reference sheet focusing on node-level troubleshooting and network debugging, crucial for certification practice. |
-    | 2026-06-03 | [github.com/learning-cloud-native-go/myapp: Learning Cloud Native Go -' myapp 🌟](https://github.com/learning-cloud-native-go/myapp) | 🔵 medium | An educational Go application specifically built to demonstrate cloud-native microservice essentials like telemetry and probe implementation. |
-
-    **AWS**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-02 | [Get started with OpenAI GPT-5.5, GPT-5.4 models, and Codex on Amazon Bedrock](https://aws.amazon.com/blogs/aws/get-started-with-openai-gpt-5-5-gpt-5-4-models-and-codex-on-amazon-bedrock) | 🔴 critical | This landmark release brings OpenAI's frontier models natively to Amazon Bedrock, breaking previous cloud hosting monopolies and providing enterprise-grade, secure access for generative AI. |
-    | 2026-03-23 | [github.com/localstack/localstack](https://github.com/localstack/localstack) | 🔴 critical | As the premier AWS cloud emulator with massive industry adoption, LocalStack is foundational for modern, local cloud-native development and offline testing pipelines. |
-    | 2025-03-25 | [aws/containers-roadmap: AWS Containers Roadmap](https://github.com/aws/containers-roadmap) | 🟡 high | This roadmap bridges developer requirements with core AWS engineering teams, offering a transparent ledger of feature designs for Kubernetes, EKS, ECS, and ECR. |
-    | 2026-04-13 | [ermetic/access-undenied-aws 🌟](https://github.com/tenable/access-undenied-aws) | 🟡 high | This tool dramatically simplifies AWS security operations by parsing CloudTrail and 'Access Denied' errors to pinpoint the exact blocking IAM policy or SCP. |
-    | 2026-06-02 | [Introducing the next generation of Amazon OpenSearch Serverless for building your agentic AI applications](https://aws.amazon.com/blogs/aws/introducing-the-next-generation-of-amazon-opensearch-serverless-for-building-your-agentic-ai-applications) | 🟡 high | The complete separation of compute and storage in this release enables true serverless scalability and highly dynamic indexing suited for agentic AI applications. |
-    | 2026-06-09 | [awslabs/amazon-ecr-credential-helper: Amazon ECR Docker Credential Helper](https://github.com/awslabs/amazon-ecr-credential-helper) | 🟡 high | It enhances container runtime security and reliability by handling seamless IAM-based ECR authentication, removing the need for periodic token-refresh cron jobs. |
-    | 2024-04-20 | [github.com/one2nc/cloudlens 🌟](https://github.com/one2nc/cloudlens) | 🔵 medium | Acting as a 'k9s' equivalent for AWS resources, this interactive terminal UI significantly streamlines resource monitoring and navigation for cloud operators. |
-    | 2026-06-02 | [Learn AWS IAM Interactively](https://www.learnawsiam.com) | 🔵 medium | This highly interactive simulator simplifies the learning curve of complex AWS IAM policy evaluation rules directly within the browser. |
-    | 2024-08-16 | [The Open Guide to Amazon Web Services](https://github.com/open-guides/og-aws) | 🔵 medium | This massive, crowd-sourced encyclopedia provides unvarnished, real-world engineering constraints and design trade-offs that official AWS documentation often omits. |
-    | 2026-06-13 | [awslabs/aws-cloudsaga: AWS CloudSaga - Simulate security events in AWS](https://github.com/awslabs/aws-cloudsaga) | 🔵 medium | This open-source tool from AWS Labs enables security operations teams to validate detection capabilities by simulating malicious security events natively. |
-
-    **Azure**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [github.com/microsoft/CBL-Mariner](https://github.com/microsoft/azurelinux) | 🔴 critical | It acts as the secure, container-optimized base OS for Azure Kubernetes Service, minimizing footprint and maximizing security for cloud-native workloads. |
-    | 2026-06-05 | [github.com/Azure/apiops 🌟](https://github.com/Azure/apiops) | 🟡 high | It brings GitOps principles to Azure API Management, enabling teams to automate the configuration and deployment of API gateways. |
-    | 2026-06-01 | [floci-az](https://github.com/floci-io/floci-az) | 🟡 high | It drastically simplifies the local development loop for cloud-native engineers by emulating core Azure services, including AKS and Functions, on a single local port. |
-    | 2026-06-02 | [From Prompt to Production: Open in VS Code for Terraform in Azure Copilot](https://techcommunity.microsoft.com/blog/azuretoolsblog/from-prompt-to-production-open-in-vs-code-for-terraform-in-azure-copilot/4494931) | 🟡 high | It merges generative AI with modern IaC practices by allowing developers to generate and open Terraform manifests directly from Azure Copilot in VS Code. |
-    | 2026-06-02 | [Azure Hub-and-Spoke Generally Available for HCP Vault Dedicated](https://www.hashicorp.com/blog/azure-hub-and-spoke-generally-available-for-hcp-vault-dedicated) | 🟡 high | It bridges enterprise secret management and secure networking by enabling managed HashiCorp Vault deployments within standard Azure hub-and-spoke architectures. |
-    | 2025-01-14 | [github.com/azure/mission-critical-online: Welcome to Azure Mission-Critical' Online Reference Implementation](https://github.com/azure/mission-critical-online) | 🟡 high | It provides an industry-grade architectural blueprint for building resilient, zero-downtime, active-active cloud applications on Azure. |
-    | 2026-06-01 | [azurearcjumpstart.io](https://jumpstart.azure.com) | 🟡 high | It streamlines hybrid cloud-native testing by providing instant, automated sandbox environments for Azure Arc-enabled Kubernetes. |
-    | 2026-06-02 | [Azure Update 22nd May 2026](https://www.youtube.com/watch?v=pMfG-vYvnv8&feature=youtu.be) | 🔵 medium | This update highlights critical cloud-native advancements, specifically the automatic instrumentation of Azure Kubernetes Service with Application Insights. |
-    | 2026-06-10 | [github.com/microsoft/finops-toolkit](https://github.com/microsoft/finops-toolkit) | 🔵 medium | It delivers the foundational open-source toolset for organizations to automate, standardize, and govern cloud financial operations across Azure. |
-    | 2026-06-14 | [Bicep](https://github.com/Azure/bicep) | 🟡 high | It serves as the premier native declarative infrastructure-as-code solution for Azure, simplifying resource provisioning over complex ARM templates. |
-
-    **GCP, OCI & Others**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [github.com/GoogleCloudPlatform/k8s-config-connector: GCP Config Connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) | 🟡 high | Enables declarative GitOps workflows by allowing engineering teams to manage Google Cloud resources directly through native Kubernetes Custom Resource Definitions. |
-    | 2026-06-13 | [Google Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpacks) | 🟡 high | Streamlines the containerization pipeline by automatically translating source code into secure, production-ready OCI images without requiring Dockerfile maintenance. |
-    | 2026-05-17 | [github.com/oracle](https://github.com/oracle) | 🟡 high | Houses the foundational Cloud Controller Manager and CSI storage plugins necessary for running production-grade Kubernetes clusters on Oracle Cloud Infrastructure. |
-    | 2026-06-18 | [engineering.mercari.com: Kubernetes based autoscaler for Cloud Spanner](https://engineering.mercari.com/en/blog/entry/20211222-kubernetes-based-spanner-autoscaler) | 🔵 medium | Offers a highly practical, real-world architectural reference for building custom Kubernetes-native autoscalers to manage external managed databases like Cloud Spanner. |
-    | 2026-06-14 | [Red Hat's approach to Edge Computing 🌟](https://www.redhat.com/en/solutions/edge-computing-approach) | 🟡 high | Pushes the cloud-native frontier into edge computing using single-node OpenShift and MicroShift architectures for low-latency, disconnected operations. |
-    | 2026-06-14 | [A hybrid cloud-native DevSecOps pipeline with JFrog Artifactory and GKE on-prem 🌟](https://docs.cloud.google.com/architecture) | 🟡 high | Delivers an enterprise-grade hybrid blueprint for secure container lifecycles by pairing GKE on-prem with JFrog Artifactory. |
-    | 2026-06-01 | [cloud.google.com: Choose the best way to use and authenticate service accounts on Google Cloud](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) | 🔴 critical | Establishes critical security protocols for GKE deployments, strongly advocating for Workload Identity over high-risk, static service account JSON keys. |
-    | 2026-06-01 | [cloud.google.com: Consume services faster, privately and securely - Private Service Connect now in GA](https://cloud.google.com/blog/products/networking/private-service-connect-is-now-generally-available) | 🔴 critical | Re-architects enterprise cloud networking by allowing private, secure connections across disjointed VPC networks and SaaS providers without public internet exposure. |
-    | 2026-06-01 | [cloud.google.com: Microservices architecture on Google Cloud](https://cloud.google.com/blog/topics/developers-practitioners/microservices-architecture-google-cloud) | 🟡 high | Provides the definitive reference guide for structuring, deploying, and securing enterprise microservices using GKE and Anthos Service Mesh. |
-    | 2026-06-01 | [OpenShift in Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/openshift-container-platform-4x) | 🟡 high | Bridges multi-cloud boundaries by providing a fully managed, joint-engineered OpenShift platform natively integrated within Microsoft Azure's infrastructure. |
-
-    **OpenShift / Red Hat**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-12 | [github.com/openshift/hypershift: HyperShift](https://github.com/openshift/hypershift) | 🔴 critical | Decouples and containerizes the OpenShift control plane, initiating a massive paradigm shift towards faster, more cost-effective multi-cluster management. |
-    | 2026-06-01 | [Amazon Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift/aws) | 🔴 critical | Offloads operational complexity through a fully managed, jointly supported native service on AWS, driving massive enterprise adoption. |
-    | 2026-06-11 | [Red Hat OLM](https://github.com/operator-framework/operator-lifecycle-manager) | 🔴 critical | Acts as the standard orchestrator for managing the lifecycle, dependencies, and updates of enterprise operators across any Kubernetes cluster. |
-    | 2026-06-18 | [OpenShift 4 documentation 🌟](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22) | 🔴 critical | Serving as the definitive operational manual for version 4.22, it provides critical guidance on lifecycle management and security policies for production clusters. |
-    | 2026-06-14 | [github.com/openshift/installer openshift installer 🌟](https://github.com/openshift/installer) | 🔴 critical | As the engine behind IPI/UPI installations, it standardizes automated, infrastructure-aware bootstrapping of OpenShift clusters across cloud providers. |
-    | 2026-06-01 | [ARO](https://www.redhat.com/en/technologies/cloud-computing/openshift/azure) | 🔴 critical | Enables seamless, co-engineered Azure integrations and unified billing, making it a leading choice for enterprise hybrid cloud deployments. |
-    | 2026-06-09 | [Machine API](https://github.com/openshift/machine-api-operator/tree/main) | 🟡 high | Enables true declarative node scaling and self-healing lifecycle management by natively integrating Cluster API patterns inside OpenShift. |
-    | 2026-06-08 | [github.com/redhat-cop/gitops-catalog](https://github.com/redhat-cop/gitops-catalog) | 🟡 high | Provides production-grade, community-validated GitOps templates and Argo CD blueprints crucial for automating enterprise cluster configurations. |
-    | 2026-06-18 | [Developer Sandbox](https://developers.redhat.com/developer-sandbox) | 🟡 high | Provides zero-cost, immediate access to fully configured OpenShift environments, dramatically lowering the barrier to entry for cloud-native developers. |
-    | 2026-06-11 | [GitHub: OKD4](https://github.com/okd-project/okd/blob/master/README.md) | 🟡 high | Represents the vital open-source upstream community distribution that bridges Fedora CoreOS with advanced cloud-native features. |
-
-    **Virtualization & Private Cloud**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [ClusterAPI](https://cluster-api.sigs.k8s.io) | 🔴 critical | Cluster API standardizes declarative, Kubernetes-style lifecycle management of clusters across private hypervisors and bare metal. |
-    | 2026-06-14 | [Openshift Container Platform](https://nubenetes.com/openshift) | 🔴 critical | Red Hat OpenShift remains the premier enterprise platform integrating traditional virtualization with modern cloud-native workloads. |
-    | 2026-06-14 | [Rancher: Enterprise management for Kubernetes](https://nubenetes.com/rancher) | 🔴 critical | Rancher provides a unified, highly adopted control plane to simplify heterogeneous cluster operations on private and bare-metal servers. |
-    | 2026-06-14 | [**Kubespray**](https://github.com/kubernetes-sigs/kubespray) | 🟡 high | Kubespray offers the most flexible, production-grade Ansible automation for deploying Kubernetes clusters on existing private cloud infrastructure. |
-    | 2025-12-05 | [Kubeinit 🌟](https://github.com/kubeinit/kubeinit) | 🟡 high | Kubeinit specifically addresses the virtualization space by automating K8s and OpenShift deployments on KVM/libvirt hypervisors. |
-    | 2026-06-12 | [defenseunicorns/zarf](https://github.com/zarf-dev/zarf) | 🟡 high | Zarf simplifies the packaging and deployment of secure, cloud-native apps into highly restricted and disconnected private cloud environments. |
-    | 2026-06-01 | [Kubernetes Cluster with **Kubeadm**](https://github.com/kubernetes/kubeadm) | 🟡 high | Kubeadm serves as the official, foundational bootstrapping engine that drives node onboarding and cluster building in private cloud environments. |
-    | 2026-06-01 | [Nomad](https://developer.hashicorp.com/nomad) | 🟡 high | Nomad is a powerful, lightweight alternative to Kubernetes that simplifies scheduling virtualized and containerized workloads across private infrastructure. |
-    | 2026-06-13 | [K0s - Zero Friction Kubernetes](https://github.com/k0sproject/k0s) | 🔵 medium | k0s reduces operational friction by packaging a fully compliant, enterprise-grade Kubernetes control plane into a single binary ideal for private cloud edge. |
-    | 2026-06-01 | [kurl.sh](https://kurl.sh) | 🔵 medium | kurl.sh allows enterprises to build custom, production-ready Kubernetes installers tailored specifically for air-gapped private cloud deployments. |
-
-
 === "Last 6 Months"
-
-    **Kubernetes & Orchestration**
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -358,325 +40,7 @@ search:
     | 2026-06-13 | [K9s - Kubernetes CLI To Manage Your Clusters In Style!](https://github.com/derailed/k9s) | 🔵 medium | Remains the gold standard CLI dashboard for SREs and platform engineers to interactively debug, trace, and manage real-time cluster workloads. |
     | 2026-06-13 | [k8gb 🌟](https://github.com/k8gb-io/k8gb) | 🔵 medium | Solves multi-region geo-redundancy natively in Kubernetes using CoreDNS integration for global server load balancing without vendor lock-in. |
 
-    **Containers & Runtime**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-13 | [containerd - An open and reliable container runtime](https://github.com/containerd/containerd) | 🔴 critical | It serves as the industry-standard container runtime powering modern Kubernetes clusters globally following Docker shim deprecation. |
-    | 2026-06-14 | [buildkit](https://docs.docker.com/build) | 🔴 critical | It represents a major paradigm shift in container image building, introducing concurrent stages and highly efficient caching. |
-    | 2026-06-01 | [podman](https://podman.io) | 🔴 critical | It drives the enterprise transition toward daemonless, rootless container management and native Kubernetes integration. |
-    | 2026-06-01 | [Dapr](https://dapr.io) | 🟡 high | It provides a highly modular sidecar architecture that standardizes state management and pub/sub for distributed container runtimes. |
-    | 2026-06-01 | [knative.dev](https://knative.dev) | 🟡 high | It is the premier Kubernetes-native platform for orchestrating scale-to-zero serverless container workloads. |
-    | 2026-06-13 | [runc](https://github.com/opencontainers/runc) | 🟡 high | It remains the canonical, industry-standard low-level OCI runtime engine that directly spawns containers on Linux. |
-    | 2026-06-01 | [buildah](https://buildah.io) | 🟡 high | It enables secure, daemonless creation of OCI-compliant container images, dramatically reducing the pipeline security footprint. |
-    | 2026-06-12 | [**GitHub build-push-action**](https://github.com/docker/build-push-action) | 🟡 high | It functions as the ubiquitous enterprise pipeline standard for automating Docker Buildx and multi-platform container image compilation. |
-    | 2026-06-14 | [cert-manager/cert-manager](https://github.com/cert-manager/cert-manager) | 🟡 high | It is the industry-standard tool for automating certificate lifecycles to ensure encrypted communication between cloud-native runtimes. |
-    | 2026-05-30 | [crun](https://github.com/containers/crun) | 🔵 medium | It offers an ultra-fast, low-memory, C-based alternative to runc with native support for advanced Linux namespace features. |
-
-    **Networking & Service Mesh**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [github.com: Istio](https://github.com/istio/istio) | 🔴 critical | As the industry-standard service mesh, Istio defines the state of the art for zero-trust security, traffic management, and observability in enterprise Kubernetes. |
-    | 2026-06-12 | [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api) | 🔴 critical | This official, highly expressive next-generation routing specification fundamentally replaces the legacy Ingress resource to unify edge and service-mesh configurations. |
-    | 2026-05-17 | [github.com/containernetworking 🌟](https://github.com/containernetworking) | 🔴 critical | This repository hosts the foundational CNI specification and core plugins that govern container networking across the entire cloud-native ecosystem. |
-    | 2026-06-01 | [Linkerd](https://linkerd.io) | 🔴 critical | Linkerd provides an ultra-lightweight, Rust-powered, and CNCF-graduated alternative to heavy Envoy-based service meshes with native automatic mTLS. |
-    | 2026-06-14 | [Envoy Gateway](https://github.com/envoyproxy/gateway) | 🟡 high | It unifies ingress controller standards by bringing the Gateway API directly to the Envoy Proxy, simplifying cloud-native edge architectures. |
-    | 2026-06-02 | [Consul 2.0 improves flexibility, control, and scalability](https://www.hashicorp.com/blog/consul-20-improves-flexibility-control-and-scalability) | 🟡 high | The release of Consul 2.0 introduces multi-port service mesh support and multi-cloud security advancements, strengthening its place in enterprise architectures. |
-    | 2026-06-14 | [NodeLocal DNSCache](https://github.com/kubernetes/enhancements) | 🟡 high | This architectural enhancement eliminates DNS performance bottlenecks and latency spikes at scale by caching queries locally on every cluster node. |
-    | 2026-06-14 | [NetBox IPAM 🌟](https://github.com/netbox-community/netbox) | 🟡 high | NetBox serves as the industry-standard single source of truth for programmable IP address management (IPAM) and infrastructure automation. |
-    | 2026-06-01 | [Meshery.io:](https://meshery.io) | 🔵 medium | This CNCF tool simplifies multi-mesh operations by enabling unified performance benchmarking, conformance testing, and design across diverse service meshes. |
-    | 2026-06-08 | [Flannel](https://github.com/flannel-io/flannel) | 🔵 medium | Flannel remains a highly stable, lightweight, and foundational CNI solution widely used for simple Kubernetes networking installations. |
-
-    **Architecture & Microservices**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-10 | [Awesome microservices](https://github.com/mfornos/awesome-microservices) | 🟡 high | Provides a definitive directory of microservices patterns, API gateways, and event-streaming components vital for building decoupled systems. |
-    | 2026-01-04 | [Awesome Scalability](https://github.com/binhnguyennus/awesome-scalability) | 🔴 critical | Offers foundational structural design patterns for building scalable, highly available backend architectures and microservices environments. |
-    | 2026-06-08 | [rootsongjc/awesome-cloud-native 🌟](https://github.com/rootsongjc/awesome-cloud-native) | 🟡 high | Systematically maps the CNCF ecosystem, providing cloud-native architects with curated guidelines on service meshes, logging, and storage. |
-    | 2026-05-25 | [anderseknert/awesome-opa 🌟](https://github.com/open-policy-agent/awesome-opa) | 🟡 high | Enables policy-as-code enforcement across Kubernetes and microservices using Open Policy Agent (OPA), a graduated CNCF project. |
-    | 2026-04-25 | [github.com/calvin-puram: Awesome Kubernetes Operator Resources](https://github.com/calvin-puram/awesome-kubernetes-operator-resources) | 🟡 high | Acts as a premier reference for developing Kubernetes Operators to automate complex, stateful application deployments. |
-    | 2026-05-30 | [clusterpedia-io/clusterpedia 🌟](https://github.com/clusterpedia-io/clusterpedia) | 🟡 high | Introduces a highly novel multi-cluster search engine that synchronizes Kubernetes resources across environments to simplify management. |
-    | 2026-06-09 | [mingrammer/diagrams](https://github.com/mingrammer/diagrams) | 🟡 high | Shifts the documentation paradigm by enabling architects to write complex cloud infrastructure diagrams dynamically as Python code. |
-    | 2022-11-10 | [Awesome API Management Tools](https://github.com/mailtoharshit/Awesome-Api-Management-Tools) | 🔵 medium | Crucial for microservices governance, cataloging tools that manage API gateways, design portals, and OpenAPI specifications. |
-    | 2026-06-14 | [Terraform Kubernetes Boilerplates 🌟](https://nubenetes.com/terraform) | 🟡 high | Provides enterprise-grade, pre-tested Terraform configurations for establishing secure and standardized public cloud Kubernetes infrastructure. |
-    | 2026-06-10 | [Awesome Compose 🌟](https://github.com/docker/awesome-compose) | 🔵 medium | Offers official, curated declarative multi-container topology configurations essential for orchestrating localized microservice stacks. |
-
-    **Data, Messaging & Storage**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Apache Kafka](https://kafka.apache.org) | 🔴 critical | The de facto industry standard for high-throughput, fault-tolerant distributed event streaming. |
-    | 2026-06-01 | [strimzi.io](https://strimzi.io) | 🔴 critical | The premier cloud-native operator for running and managing production-grade Apache Kafka clusters on Kubernetes. |
-    | 2026-06-01 | [Longhorn](https://longhorn.io) | 🔴 critical | A graduated CNCF project offering robust, easy-to-use, and lightweight distributed block storage designed specifically for Kubernetes. |
-    | 2026-06-01 | [min.io](https://www.min.io) | 🔴 critical | The leading high-performance, S3-compatible object storage platform optimized for native Kubernetes deployments. |
-    | 2026-06-01 | [Redpanda 🌟](https://www.redpanda.com) | 🟡 high | Re-engineers event streaming in C++ to achieve ultra-low latency and JVM-free operations while maintaining full Kafka API compatibility. |
-    | 2026-06-12 | [github.com/vmware-tanzu/velero](https://github.com/velero-io/velero) | 🔴 critical | The standard open-source utility for backing up, restoring, and migrating Kubernetes cluster resources and persistent volumes. |
-    | 2026-06-01 | [**Debezium**:](https://debezium.io) | 🟡 high | The industry-standard distributed platform for log-based Change Data Capture (CDC) to enable real-time database event streams. |
-    | 2026-06-01 | [Apache Flink](https://flink.apache.org) | 🟡 high | The leading framework for processing stateful real-time data streams with millisecond latency and robust fault tolerance. |
-    | 2026-06-12 | [Zalando Postgres Operator](https://github.com/zalando/postgres-operator) | 🟡 high | Simplifies day-2 operations for mission-critical PostgreSQL databases on Kubernetes by automating high-availability, scaling, and backups. |
-    | 2026-06-01 | [OpenEBS](https://openebs.io) | 🟡 high | A highly flexible, cloud-native container-attached storage system that transforms local storage into dynamic persistent volumes. |
-
-    **AI & Agents**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [vLLM on Kubernetes](https://github.com/vllm-project/vllm) | 🔴 critical | It standardizes high-performance, memory-efficient LLM serving via vLLM on Kubernetes clusters, directly bridging cloud-native infrastructure with AI workloads. |
-    | 2026-06-18 | [antigravity.google: Google Antigravity Agentic Platform](https://antigravity.google) | 🔴 critical | This unified platform and SDK allows developers to seamlessly transition stateful AI agents from local prototypes to production-grade Google Kubernetes Engine deployments. |
-    | 2026-06-02 | [Announcing Claude Managed Agents on Cloudflare](https://blog.cloudflare.com/claude-managed-agents) | 🔴 critical | The partnership provides a secure, sandboxed execution plane at the cloud edge for hosting and running autonomous agent workflows safely. |
-    | 2026-06-18 | [docs.anthropic.com: Claude Code CLI](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | 🟡 high | Anthropic's official CLI agent transforms developer workflows by autonomously interacting with codebases, running tests, and managing git operations directly. |
-    | 2026-06-18 | [cursor.com: Cursor AI Code Editor](https://cursor.com) | 🟡 high | As the leading AI-first code editor, its multi-file agentic code generation features have fundamentally changed how software engineering teams write and refactor code daily. |
-    | 2026-06-07 | [GitHub MCP Server](https://github.com/modelcontextprotocol/servers) | 🟡 high | This repository establishes critical development standards for the Model Context Protocol (MCP), enabling structured, secure communication between host agents and tools. |
-    | 2026-06-13 | [LocalAI](https://github.com/mudler/LocalAI) | 🟡 high | It provides a crucial self-hosted, OpenAI-compatible API gateway that enables teams to run private, local LLMs within secure cloud-native environments. |
-    | 2025-06-01 | [CAST AI](https://cast.ai) | 🟡 high | By utilizing real-time AI algorithms to automate resource scaling and spot instance configuration, it dramatically reduces cloud spend for managed Kubernetes clusters. |
-    | 2026-06-10 | [Google Agents CLI](https://github.com/google/agents-cli) | 🟡 high | Google's official CLI leverages the Model Context Protocol to streamline the design, testing, and deployment of complex agentic task orchestration workflows. |
-    | 2026-06-14 | [OpenOps: No-Code FinOps Automation Platform with AI](https://github.com/openops-cloud/openops) | 🔵 medium | It integrates AI-driven cost optimization directly with Kubernetes metrics, providing a no-code FinOps solution to automate resource rightsizing. |
-
-    **MLOps & Data Science**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Ray](https://docs.ray.io/en/latest) | 🔴 critical | As the dominant distributed execution framework for AI, Ray is foundational for scaling compute-heavy workloads across cloud-native environments. |
-    | 2026-05-17 | [openai.com: Scaling Kubernetes to 7,500 nodes 🌟](https://openai.com/research/scaling-kubernetes-to-7500-nodes) | 🔴 critical | This landmark case study provides invaluable infrastructure blueprints for scaling Kubernetes to handle massive, state-of-the-art AI/ML training workloads. |
-    | 2026-06-13 | [github.com/Netflix/metaflow 🌟](https://github.com/Netflix/metaflow) | 🔴 critical | Netflix's production-proven framework seamlessly bridges local data science development with enterprise-scale cloud infrastructure and orchestration. |
-    | 2026-05-19 | [github.com/meta-llama/llama-recipes](https://github.com/meta-llama/llama-cookbook) | 🟡 high | Provides industry-standard templates for parameter-efficient fine-tuning and optimization, defining modern LLMOps deployment patterns. |
-    | 2026-05-17 | [medium.com/workday-engineering: Implementing a Fully Automated Sharding' Strategy on Kubernetes for Multi-tenanted Machine Learning Applications](https://medium.com/workday-engineering/implementing-a-fully-automated-sharding-strategy-on-kubernetes-for-multi-tenanted-machine-learning-4371c48122ae) | 🟡 high | Solves critical multi-tenancy and resource isolation challenges for ML applications at enterprise scale using native Kubernetes sharding. |
-    | 2026-06-18 | [mikeroyal/Kubernetes-Guide: Machine Learning 🌟](https://github.com/mikeroyal/Kubernetes-Guide/blob/main/README.md) | 🟡 high | Serves as an essential technical reference mapping out configurations and architectural patterns for running diverse ML workloads on Kubernetes. |
-    | 2026-05-17 | [medium.com/@bchenjh: Distributed full fine-tuning of Llama2 on Kubernetes](https://medium.com/@bchenjh/full-fine-tuning-of-llama2-on-kubernetes-a983e1eb2259) | 🟡 high | Demonstrates a practical, cloud-native pattern for executing complex, distributed LLM fine-tuning directly on Kubernetes clusters. |
-    | 2026-06-08 | [rubrix](https://github.com/argilla-io/argilla) | 🟡 high | A critical open-source platform that enables human-in-the-loop data curation, which is essential for continuous alignment of modern generative AI models. |
-    | 2026-05-21 | [tensorchord/envd: Reproducible development environment for AI/ML 🌟](https://github.com/tensorchord/envd) | 🔵 medium | Simplifies the ML-to-cloud transition by automatically packaging Python declarations into highly reproducible, CUDA-enabled containers. |
-    | 2026-05-17 | [medium.com/bakdata: Scalable Machine Learning with Kafka Streams and KServe](https://medium.com/bakdata/scalable-machine-learning-with-kafka-streams-and-kserve-85308858d867) | 🔵 medium | Showcases a robust, event-driven architecture for scaling real-time model inference using KServe and Kafka on Kubernetes. |
-
-    **Python, Java & Developer Ecosystem**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [metalbear-co/mirrord](https://github.com/metalbear-co/mirrord) | 🟡 high | It revolutionizes cloud-native debugging by letting developers run local processes seamlessly inside remote Kubernetes namespaces without image rebuilds. |
-    | 2026-06-14 | [Ruff](https://github.com/astral-sh/ruff) | 🔴 critical | It has become the de facto standard for Python linting and formatting, drastically reducing CI/CD runtimes due to its high-performance Rust implementation. |
-    | 2026-06-14 | [testcontainers-spring-boot 🌟](https://github.com/PlaytikaOSS/testcontainers-spring-boot) | 🟡 high | It standardizes enterprise integration testing in Java by automating the local lifecycle of Docker dependencies like databases and message brokers directly within JUnit tests. |
-    | 2026-06-13 | [github.com/spring-projects: springboot enables these probes automatically when running in k8s](https://github.com/spring-projects/spring-boot#L73) | 🟡 high | It simplifies Kubernetes deployments by automatically detecting the host platform and exposing cloud-native liveness and readiness probes out of the box. |
-    | 2026-06-13 | [pydantic/pydantic](https://github.com/pydantic/pydantic) | 🔴 critical | As the industry standard for Python data validation, its high-performance Rust engine (V2) enforces type safety and schema definitions at scale in microservices. |
-    | 2026-06-12 | [apache/maven-mvnd](https://github.com/apache/maven-mvnd) | 🟡 high | It significantly accelerates Java development loops by using a persistent background daemon to eliminate Maven compilation overhead. |
-    | 2026-06-12 | [github: Spring Cloud Kubernetes 🌟](https://github.com/spring-cloud/spring-cloud-kubernetes) | 🟡 high | It bridges the gap between Java microservices and Kubernetes infrastructure by mapping ConfigMaps and Secrets directly to the Spring environment. |
-    | 2026-06-12 | [github.com/bloomberg/memray 🌟🌟](https://github.com/bloomberg/memray) | 🟡 high | It provides high-fidelity memory profiling for Python applications, which is critical for debugging resource leaks in containerized microservices. |
-    | 2026-06-01 | [quarkus.io](https://quarkus.io) | 🔴 critical | It redefines modern Java for the cloud-native era by optimizing boot times and memory usage specifically for GraalVM and Kubernetes environments. |
-    | 2026-06-01 | [Spring Cloud](https://spring.io/projects/spring-cloud) | 🔴 critical | It remains the foundational standard for orchestrating distributed systems patterns, routing, and configuration management across enterprise Java microservices. |
-
-    **Linux & System Foundations**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [redhat.com: World domination with cgroups part 8: down and dirty with cgroup v2](https://www.redhat.com/en/blog/world-domination-cgroups-part-8-down-and-dirty-cgroup-v2) | 🔴 critical | cgroup v2 is the foundational resource control layer enabling memory pressure stalls and unified resource management in modern container engines. |
-    | 2026-06-13 | [bpftrace](https://github.com/bpftrace/bpftrace) | 🔴 critical | eBPF-driven bpftrace provides safe, high-performance, dynamic kernel and userspace tracing essential for cloud-native performance analysis. |
-    | 2026-03-05 | [How-To Secure A Linux Server](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server) | 🟡 high | Provides a comprehensive, production-grade security blueprint indispensable for hardening enterprise Linux node installations. |
-    | 2024-04-30 | [termshark](https://github.com/gcla/termshark) | 🟡 high | Enables interactive, packet-level network debugging over remote SSH and container network namespaces without exporting massive PCAPs. |
-    | 2026-01-05 | [github: Safe ways to do things in bash](https://github.com/anordal/shellharden/blob/master/how_to_do_things_safely_in_bash.md) | 🟡 high | Establishes bulletproof shell scripting standards to prevent silent failures and security vulnerabilities in critical system and container entrypoints. |
-    | 2026-06-13 | [zx](https://github.com/google/zx) | 🟡 high | Modernizes infrastructure glue code by providing a safe, JavaScript-based execution engine that replaces fragile traditional shell scripts. |
-    | 2026-06-01 | [sysadminxpert.com: How to watch real time TCP and UDP ports on Linux (netstat & ss) 🌟](https://sysadminxpert.com/how-to-watch-real-time-tcp-and-udp-ports-on-linux) | 🔵 medium | Provides critical comparative diagnostics of modern socket tracking, essential for debugging routing, firewalls, and networking on Linux hosts. |
-    | 2026-06-01 | [**curl command**: Understanding the Hidden Powers of curl](https://nordicapis.com/understanding-the-hidden-powers-of-curl) | 🔵 medium | Details advanced curl capabilities like raw TCP manipulation and proxy tunneling crucial for diagnosing cloud API connectivity and ingress paths. |
-    | 2026-06-01 | [abarrak.gitbook.io: Linux SysOps Handbook 🌟](https://abarrak.gitbook.io/linux-sysops-handbook) | 🔵 medium | Serves as a high-density, real-world reference handbook that accelerates on-call incident resolution and performance tuning. |
-    | 2026-06-01 | [igoroseledko.com: Parallel Rsync](https://www.igoroseledko.com/parallel-rsync) | 🔵 medium | Solves single-thread performance bottlenecks during massive data migrations by parallelizing rsync workflows over enterprise networks. |
-
-    **Security & Compliance**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-12 | [hashicorp/vault](https://github.com/hashicorp/vault) | 🔴 critical | It is the undisputed industry-standard tool for multi-cloud secrets management, dynamic credential brokering, and zero-trust data protection. |
-    | 2026-05-17 | [OPA Open Policy Agent 🌟](https://www.openpolicyagent.org) | 🔴 critical | As a CNCF graduated project, OPA remains the foundational standard for unifying fine-grained, declarative policy-as-code enforcement across microservices. |
-    | 2026-06-11 | [trivy](https://github.com/aquasecurity/trivy) | 🔴 critical | It is the de facto standard for rapid container, package, and Infrastructure-as-Code vulnerability scanning integrated into modern CI/CD pipelines. |
-    | 2025-06-01 | [external-secrets.io 🌟](https://external-secrets.io) | 🟡 high | It is the industry-standard operator that securely bridges external secret management backends directly into native Kubernetes Secrets. |
-    | 2026-06-14 | [Tetragon (Cilium)](https://github.com/cilium/tetragon) | 🟡 high | Provides cutting-edge, eBPF-powered real-time security observability and runtime kernel enforcement to block threats before they reach the application layer. |
-    | 2026-06-18 | [Project Calico 🌟](https://www.tigera.io/project-calico) | 🟡 high | An industry-standard networking and network security engine that leverages eBPF to enforce high-performance microsegmentation policies. |
-    | 2026-06-13 | [github.com/prowler-cloud/prowler 🌟🌟](https://github.com/prowler-cloud/prowler) | 🟡 high | A premier tool for Cloud Security Posture Management (CSPM), enabling automated compliance auditing across multi-cloud environments against global standards. |
-    | 2026-05-17 | [checkov.io](https://www.checkov.io) | 🟡 high | A leading static analysis tool that actively prevents cloud misconfigurations by scanning Infrastructure-as-Code blueprints before deployment. |
-    | 2026-06-12 | [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator) | 🟡 high | A Kubernetes SIG-managed project that simplifies the native orchestrating and hardening of Seccomp, AppArmor, and SELinux profiles. |
-    | 2026-06-12 | [kubescape](https://github.com/kubescape/kubescape) | 🟡 high | An active CNCF Sandbox platform that automates multi-framework Kubernetes configuration scanning, risk profiling, and compliance management. |
-
-    **Infrastructure as Code**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-02 | [OpenTofu 1.12: the Feature Terraform Never Shipped](https://www.infoq.com/news/2026/05/opentofu-release-terraform) | 🔴 critical | Successfully solves a long-standing limitation in modular configuration, marking a significant milestone for the OpenTofu open-source fork. |
-    | 2026-06-02 | [The Agentic Infrastructure Era \| Pulumi Releases](https://www.pulumi.com/releases/agentic-infrastructure-era) | 🔴 critical | Introduces a major paradigm shift toward autonomous, agent-driven cloud provisioning and self-healing infrastructure systems. |
-    | 2026-06-02 | [New in Terraform 1.15: Dynamic sources, variable deprecation, and more](https://www.hashicorp.com/en/blog/new-in-terraform-115-dynamic-sources-variable-deprecation-and-more) | 🔴 critical | Introduces native dynamic module sources and versioning, fundamentally changing how practitioners configure upstream dependencies at initialization. |
-    | 2026-05-29 | [github.com/terraform-aws-modules/terraform-aws-eks: AWS EKS Terraform module](https://github.com/terraform-aws-modules/terraform-aws-eks) | 🟡 high | Serves as the battle-tested, community-standard blueprint for orchestrating complex enterprise Amazon EKS cluster deployments. |
-    | 2025-12-10 | [terraform-cdk 🌟](https://github.com/hashicorp/terraform-cdk) | 🟡 high | Allows software engineering teams to use imperative languages like TypeScript and Python to build declarative cloud native infrastructure. |
-    | 2025-06-01 | [terragrunt.gruntwork.io](https://terragrunt.com) | 🟡 high | Remains the industry-standard orchestrator for keeping large-scale IaC configurations DRY and managing complex cross-module dependencies. |
-    | 2026-05-27 | [mineiros-io/terramate](https://github.com/terramate-io/terramate) | 🟡 high | Optimizes large-scale multi-directory monorepos with advanced selective change detection and automated code generation. |
-    | 2026-06-10 | [AWX Operator](https://github.com/ansible/awx-operator) | 🟡 high | Enables Kubernetes-native lifecycle management, scaling, and CRD-driven automation of Ansible AWX deployments. |
-    | 2026-06-03 | [Infracost 🌟](https://github.com/infracost/infracost) | 🟡 high | Integrates directly into CI/CD pipelines to provide real-time FinOps cloud cost projections before resources are provisioned. |
-    | 2026-03-05 | [Kubestack Gitops Framework](https://github.com/kbst/terraform-kubestack) | 🟡 high | Bridges the gap between declarative cloud infrastructure and GitOps application delivery workflows on Kubernetes. |
-
-    **CI/CD & GitOps**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Argo CD](https://argoproj.github.io/argo-cd) | 🔴 critical | Argo CD remains the absolute industry standard for pull-based GitOps reconciliation and continuous delivery on Kubernetes. |
-    | 2026-06-13 | [github: Flux Version 2](https://github.com/fluxcd/flux2) | 🔴 critical | Flux v2 is a foundational, graduated CNCF GitOps engine engineered specifically for highly decoupled, parallel cluster synchronization. |
-    | 2026-06-14 | [dagger/dagger: Dagger is a portable devkit for CICD](https://github.com/dagger/dagger) | 🔴 critical | Dagger represents a major paradigm shift in CI/CD, replacing fragile YAML/Bash scripts with portable pipelines written in standard languages and executed via BuildKit. |
-    | 2026-06-14 | [Helm](https://nubenetes.com/helm) | 🟡 high | Helm is the undisputed standard package manager for Kubernetes, serving as a critical packaging cornerstone for modern GitOps engines. |
-    | 2026-06-14 | [github: Tekton Pipelines](https://github.com/tektoncd/pipeline) | 🟡 high | Tekton provides the standard cloud-native CI/CD framework using Kubernetes-native Custom Resource Definitions for structured, scalable task execution. |
-    | 2026-06-08 | [github.com/flux-iac/tofu-controller](https://github.com/flux-iac/tofu-controller) | 🟡 high | The OpenTofu controller natively extends GitOps synchronization paradigms beyond Kubernetes manifests to cloud infrastructure resources. |
-    | 2025-06-01 | [Jenkins Configuration as Code](https://www.jenkins.io/projects/jcasc) | 🟡 high | Jenkins Configuration as Code (JCasC) provides a critical production-ready path to manage legacy CI infrastructure under modern GitOps and declarative paradigms. |
-    | 2026-06-13 | [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) | 🟡 high | Prow is the leading cloud-native CI/CD platform engineered to handle massive-scale, decentralized, event-driven repository governance. |
-    | 2026-06-14 | [github.com/glasskube/glasskube](https://github.com/glasskube/glasskube) | 🟡 high | Glasskube represents a major technical novelty as a next-generation Kubernetes package manager designed to simplify dependency management and upgrades over traditional Helm. |
-    | 2026-06-14 | [feat(ui): Add AppSet to Application Resource Tree in Argo CD](https://github.com/argoproj/argo-cd/pull/26601) | 🔵 medium | This Argo CD enhancement directly improves enterprise observability for multi-tenant topologies by natively mapping ApplicationSets in the dashboard UI. |
-
-    **Observability, SRE & Testing**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-13 | [github.com/prometheus/prometheus](https://github.com/prometheus/prometheus) | 🔴 critical | Prometheus remains the industry-standard, benchmark telemetry engine for modern cloud-native metrics collection and real-time alerting. |
-    | 2026-06-12 | [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) | 🔴 critical | The OpenTelemetry Collector serves as the essential, vendor-agnostic pipeline engine for modern enterprise telemetry collection and routing. |
-    | 2026-05-17 | [github.com/prometheus-operator](https://github.com/prometheus-operator) | 🔴 critical | The Prometheus Operator is the foundational controller that automates the deployment, scaling, and configuration of monitoring instances in Kubernetes. |
-    | 2026-06-12 | [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) | 🟡 high | Kube-prometheus provides the definitive, production-ready reference architecture for monitoring Kubernetes control planes and node workloads. |
-    | 2026-06-13 | [Grafana Tempo](https://github.com/grafana/tempo) | 🟡 high | Grafana Tempo offers highly scalable, cost-effective distributed tracing utilizing only object storage to lower enterprise observability costs. |
-    | 2026-06-13 | [github.com/open-telemetry/opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-operator) | 🟡 high | The OpenTelemetry Operator simplifies cloud-native observability by automating collector deployments and application auto-instrumentation on Kubernetes. |
-    | 2026-06-12 | [Chaos Mesh](https://github.com/chaos-mesh/chaos-mesh) | 🟡 high | Chaos Mesh provides a powerful CNCF-incubating platform to systematically inject faults and validate system resilience in Kubernetes. |
-    | 2026-06-09 | [Litmus Chaos is a toolset to do chaos engineering in a kubernetes native way. Litmus provides chaos CRDs for Cloud-Native developers and SREs to inject, orchestrate and monitor chaos to find weaknesses in Kubernetes deployments](https://github.com/litmuschaos/litmus) | 🟡 high | Litmus Chaos enables SREs to orchestrate Kubernetes-native chaos experiments directly through declarative, CRD-driven pipelines. |
-    | 2026-06-14 | [Netdata](https://github.com/netdata/netdata) | 🟡 high | Netdata delivers ultra-high-performance, zero-configuration system monitoring with massive community adoption for real-time physical and virtual host diagnostics. |
-    | 2026-06-08 | [Sloth 🌟](https://github.com/slok/sloth) | 🔵 medium | Sloth automates SRE practices by translating simple declarative YAML definitions into complex, production-grade PromQL multi-burn-rate alerting rules. |
-
-    **DevOps & Culture**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-13 | [github.com/backstage/backstage](https://github.com/backstage/backstage) | 🔴 critical | It is the de facto industry-standard framework for building customizable internal developer portals, centralizing platform engineering workflows. |
-    | 2026-06-12 | [Azure DevOps MCP Server](https://github.com/microsoft/azure-devops-mcp) | 🟡 high | Bridges AI-native agents and Azure DevOps, enabling automated task and workflow management directly via LLMs. |
-    | 2026-06-10 | [Devtron](https://github.com/devtron-labs/devtron) | 🟡 high | Simplifies complex Kubernetes operations by unifying CI/CD, GitOps, and multi-cluster observability into a cohesive self-service portal. |
-    | 2026-06-14 | [IaC Infrastructure as Code](https://nubenetes.com/iac) | 🟡 high | Provides a critical cloud-native reference architecture for managing infrastructure and cluster state declaratively. |
-    | 2026-06-02 | [Introducing Cursor in Jira - Inside Atlassian](https://www.atlassian.com/blog/company-news/cursor-in-jira) | 🟡 high | Represents a paradigm shift in project management by integrating ticket-tracking directly with autonomous AI coding agents. |
-    | 2026-01-04 | [github.com/KusionStack/kusion](https://github.com/KusionStack/kusion) | 🟡 high | Enables intent-driven declarative configuration to streamline and unify application delivery across multi-cloud platforms. |
-    | 2026-05-29 | [action-tmate: Debug GitHub Actions via SSH](https://github.com/mxschmitt/action-tmate) | 🔵 medium | Drastically improves developer troubleshooting loops by providing secure interactive SSH access to active CI/CD runners. |
-    | 2026-06-14 | [blog.postman.com: What Is PlatformOps?](https://blog.postman.com/what-is-platformops) | 🟡 high | Defines the strategic transition from traditional DevOps to PlatformOps, treating developer tooling and infrastructure as internal products. |
-    | 2026-06-14 | [NoOps](https://nubenetes.com/noops) | 🔵 medium | Synthesizes the operational path toward abstracting infrastructure layers entirely through automation, serverless models, and self-healing systems. |
-    | 2026-06-14 | [DevOps Tools](https://nubenetes.com/devops-tools) | 🔵 medium | Curates the essential modern tooling pipeline required to orchestrate continuous integration, container scheduling, and real-time telemetry. |
-
-    **Platform Engineering & DevEx**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [Backstage Developer Portal:](https://backstage.io) | 🔴 critical | As the premier CNCF project for building internal developer portals, Backstage is the industry-standard foundation for enterprise Platform Engineering and DevEx. |
-    | 2026-06-11 | [Azure/Draft 🌟](https://github.com/Azure/draft) | 🟡 high | Streamlines cloud-native developer experience by scanning application source code to automatically generate Dockerfiles and Kubernetes manifests. |
-    | 2026-06-01 | [Kong API Manager](https://konghq.com/products/kong-gateway) | 🔴 critical | Stands as the world's most popular lightweight API gateway, serving as a critical traffic routing and policy enforcement layer in microservice platforms. |
-    | 2026-06-12 | [apisix](https://github.com/apache/apisix) | 🟡 high | Provides a high-performance, fully dynamic cloud-native API gateway built on Nginx that is ideal for handling dynamic routing and telemetry integration. |
-    | 2026-06-01 | [Material for MkDocs](https://squidfunk.github.io/mkdocs-material) | 🟡 high | Acts as the de facto industry standard UI for engineering documentation, enabling modern docs-as-code workflows that dramatically elevate DevEx. |
-    | 2026-06-01 | [docs.traefik.io](https://doc.traefik.io/traefik) | 🟡 high | Traefik is a foundational cloud-native ingress proxy designed to dynamically configure and route traffic within containerized environments. |
-    | 2026-06-01 | [Google Apigee API Manager](https://cloud.google.com/apigee) | 🟡 high | Provides enterprise-grade API management and security globally, serving as a robust centralized control plane for large-scale hybrid cloud platforms. |
-    | 2026-06-01 | [Red Hat 3scale API Management](https://www.redhat.com/en/technologies/jboss-middleware/3scale) | 🔵 medium | Delivers a Kubernetes-native, operator-driven API management framework optimized for secure microservices delivery on enterprise platforms like Red Hat OpenShift. |
-    | 2026-06-01 | [Tyk API Manager](https://tyk.io) | 🔵 medium | Offers an ultra-lightweight and highly performant Go-based API gateway with excellent multi-datacenter and dynamic clustering capabilities. |
-    | 2026-06-01 | [readme.so](https://readme.so) | 🔵 medium | Directly enhances early-stage developer experience by providing an intuitive interactive builder to standardize and accelerate repository documentation. |
-
-    **FinOps & Cloud Cost**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [FinOps Foundation: FinOps.org](https://www.finops.org) | 🔴 critical | Serves as the foundational standard-setting body codifying FinOps practices, frameworks, and open specifications like FOCUS for cloud-native architectures. |
-    | 2026-06-18 | [cncf.io: FinOps for Kubernetes: Insufficient – or nonexistent – Kubernetes' cost monitoring is causing overspend](https://www.cncf.io/blog/2021/06/29/finops-for-kubernetes-insufficient-or-nonexistent-kubernetes-cost-monitoring-is-causing-overspend) | 🔴 critical | Provides CNCF-backed guidance on why visibility and cost monitoring are crucial to stopping runaway costs in complex Kubernetes deployments. |
-    | 2026-05-17 | [engineering.razorpay.com: The Culture of Cost Optimization — Reducing Kubernetes' cost by $300,000](https://engineering.razorpay.com/the-culture-of-cost-optimization-reducing-kubernetes-cost-by-300-000-32611cdd19d9) | 🟡 high | Offers a highly valuable real-world enterprise blueprint on how cultural and technical optimizations slashed Kubernetes spending by $300,000. |
-    | 2026-05-17 | [medium.com/develeap: Cutting down Kubernetes Costs: Cast.ai vs. Karpenter](https://medium.com/develeap/cutting-down-kubernetes-costs-cast-ai-vs-karpenter-20f6788b4c67) | 🟡 high | Compares the leading automated cloud-native node provisioning technologies, Cast.ai and Karpenter, which represent the state-of-the-art in container cost optimization. |
-    | 2026-05-17 | [cast.ai: Keep your AWS Kubernetes costs in check with intelligent allocation' (EKS)](https://cast.ai/blog/keep-your-aws-kubernetes-costs-in-check-with-intelligent-allocation) | 🟡 high | Demonstrates how automated container provisioning and dynamic node scaling can drastically curb resource over-provisioning on managed Kubernetes. |
-    | 2026-04-09 | [Cloudburn: An Open-Source Policy Engine for AWS Spending](https://github.com/towardsthecloud/cloudburn) | 🟡 high | Introduces a novel open-source policy engine that applies declarative, GitOps-friendly auditing rules specifically to cloud infrastructure spending. |
-    | 2026-05-17 | [medium.com/@danielepolencic: In Kubernetes, are there hidden costs to' running many cluster nodes?](https://medium.com/@danielepolencic/reserved-cpu-and-memory-in-kubernetes-nodes-65aee1946afd) | 🟡 high | Delivers an essential technical deep-dive into the hidden overhead costs of node-level CPU and memory reservation in Kubernetes clusters. |
-    | 2026-05-18 | [thenewstack.io: 7 Tips for Cutting Down Your AWS Kubernetes Bill](https://thenewstack.io/kubernetes/7-tips-for-cutting-down-your-aws-kubernetes-bill) | 🟡 high | Compiles highly actionable, industry-standard strategies including Spot instances and auto-scalers like Karpenter to optimize EKS bills. |
-    | 2026-05-17 | [medium.com/compass-true-north: Halving Kubernetes Compute Costs With Vertical' Pod Autoscaler](https://medium.com/compass-true-north/halving-kubernetes-compute-costs-with-vertical-pod-autoscaler-df658c043301) | 🟡 high | Illustrates how utilizing the Vertical Pod Autoscaler (VPA) can automate container rightsizing and halve compute costs in production. |
-    | 2026-06-18 | [learnk8s/xlskubectl](https://github.com/learnk8s/xlskubectl) | 🔵 medium | Provides a novel technical tool that bridges the gap between engineering CLI outputs and finance spreadsheets for easy cost forecasting. |
-
-    **Certification & Training**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [The Linux Foundation Training](https://training.linuxfoundation.org/resources) | 🔴 critical | As the official home for the CKA, CKAD, and CKS curricula, this is the single most critical training source for cloud-native professionals. |
-    | 2026-06-01 | [kubernetes.io 🌟](https://kubernetes.io/docs/reference/kubectl/quick-reference) | 🟡 high | The canonical kubectl quick reference is an indispensable daily tool and exam aid for candidates preparing for hands-on CNCF certifications. |
-    | 2026-06-01 | [kube.academy](https://kube.academy) | 🟡 high | This VMware Tanzu-sponsored platform offers high-quality, free modular tracks specifically designed to teach advanced Kubernetes administration concepts. |
-    | 2026-06-01 | [Whizlabs](https://www.whizlabs.com) | 🟡 high | Provides highly realistic exam simulators and sandbox environments specifically designed for preparing candidates to pass the CKA, CKAD, and CKS. |
-    | 2026-06-01 | [edx.org](https://www.edx.org) | 🟡 high | Hosts the official introductory curricula from the Linux Foundation, acting as a primary starting point for university-grade cloud-native certificates. |
-    | 2025-04-27 | [AdminTurnedDevOps/DevOps-The-Hard-Way-AWS](https://github.com/AdminTurnedDevOps/DevOps-The-Hard-Way-AWS) | 🟡 high | Offers a rigorous, step-by-step curriculum for learning real-world cloud operations, infrastructure as code, and security scanning on AWS. |
-    | 2026-06-18 | [techiescamp/devops-projects:Real-World DevOps Projects For Learning](https://github.com/techiescamp/devops-projects) | 🟡 high | Provides comprehensive, real-world infrastructure blueprints and CI/CD templates essential for hands-on DevOps learning and portfolio building. |
-    | 2026-06-01 | [cheatsheetseries.owasp.org: OWASP Cheat Sheet Series 🌟🌟](https://cheatsheetseries.owasp.org/index.html) | 🟡 high | Serves as the ultimate application security reference, heavily utilized in training for the Certified Kubernetes Security Specialist (CKS) exam. |
-    | 2026-06-08 | [stefanprodan/podinfo](https://github.com/stefanprodan/podinfo) | 🟡 high | The de facto reference microservice used by engineers to practice and test Kubernetes deployment patterns, service meshes, and observability tools. |
-    | 2026-01-15 | [knative-tutorial](https://github.com/redhat-developer-demos/knative-tutorial) | 🔵 medium | Delivers a structured, practical tutorial for mastering Knative serving, eventing, and scale-to-zero serverless paradigms in Kubernetes. |
-
-    **AWS**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-02 | [Get started with OpenAI GPT-5.5, GPT-5.4 models, and Codex on Amazon Bedrock](https://aws.amazon.com/blogs/aws/get-started-with-openai-gpt-5-5-gpt-5-4-models-and-codex-on-amazon-bedrock) | 🔴 critical | Marks a major industry paradigm shift by bringing OpenAI's frontier models to AWS Bedrock, ending Microsoft's exclusive hosting agreement. |
-    | 2026-03-23 | [github.com/localstack/localstack](https://github.com/localstack/localstack) | 🔴 critical | Remains the absolute industry standard for local AWS emulation, enabling rapid, cost-effective cloud-native testing and development. |
-    | 2025-03-25 | [aws/containers-roadmap: AWS Containers Roadmap](https://github.com/aws/containers-roadmap) | 🔴 critical | Provides crucial transparency and direct community collaboration on the engineering roadmap for AWS container services like EKS and ECS. |
-    | 2026-06-02 | [Introducing the next generation of Amazon OpenSearch Serverless for building your agentic AI applications](https://aws.amazon.com/blogs/aws/introducing-the-next-generation-of-amazon-opensearch-serverless-for-building-your-agentic-ai-applications) | 🟡 high | Introduces a rebuilt serverless search architecture that completely decouples compute and storage for modern agentic AI workloads. |
-    | 2026-04-13 | [ermetic/access-undenied-aws 🌟](https://github.com/tenable/access-undenied-aws) | 🟡 high | Significantly simplifies AWS IAM troubleshooting by parsing Access Denied errors and pinpointing the exact blocking policy or SCP. |
-    | 2024-08-16 | [The Open Guide to Amazon Web Services](https://github.com/open-guides/og-aws) | 🟡 high | Serves as an indispensable, community-driven guide that exposes real-world AWS engineering constraints and unvarnished operational realities. |
-    | 2025-05-01 | [Metabadger](https://github.com/salesforce/metabadger) | 🟡 high | Automates the critical security hardening of EC2 instances by systematically enforcing IMDSv2 to prevent SSRF exploitation. |
-    | 2024-01-09 | [saml-to/assume-aws-role-action](https://github.com/saml-to/assume-aws-role-action) | 🟡 high | Enhances CI/CD pipeline security by leveraging OIDC to assume AWS IAM roles, eliminating the need for risky long-lived static credentials. |
-    | 2026-06-02 | [From Silos to Service Topology: Why Netflix Built a Real-Time Service Map](https://netflixtechblog.com/from-silos-to-service-topology-why-netflix-built-a-real-time-service-map-0165ba13a7bc?source=rss----2615bd06b42e---4) | 🟡 high | Demonstrates next-generation observability by correlating eBPF network flows with service registries to map complex microservice architectures. |
-    | 2026-06-13 | [awslabs/aws-cloudsaga: AWS CloudSaga - Simulate security events in AWS](https://github.com/awslabs/aws-cloudsaga) | 🟡 high | Enables security operations teams to validate detection mechanisms by simulating malicious activities directly inside AWS environments. |
-
-    **Azure**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [github.com/microsoft/CBL-Mariner](https://github.com/microsoft/azurelinux) | 🔴 critical | Delivers a lightweight, highly secure, container-optimized base OS purpose-built to minimize the attack surface of AKS workloads. |
-    | 2026-06-14 | [Bicep](https://github.com/Azure/bicep) | 🟡 high | Acts as the standard, developer-friendly declarative alternative to raw ARM templates for modular and validated Azure infrastructure provisioning. |
-    | 2026-06-10 | [github.com/microsoft/finops-toolkit](https://github.com/microsoft/finops-toolkit) | 🟡 high | Standardizes enterprise cost governance by orchestrating Azure compute optimizations, amortization data, and Power BI dashboards in one toolkit. |
-    | 2026-06-05 | [github.com/Azure/apiops 🌟](https://github.com/Azure/apiops) | 🟡 high | Brings GitOps automation to Azure API Management, allowing teams to seamlessly extract, publish, and control API configurations. |
-    | 2026-06-01 | [azurearcjumpstart.io](https://jumpstart.azure.com) | 🟡 high | Provides a vital, fully automated sandbox framework to accelerate the evaluation and deployment of hybrid Azure Arc-enabled Kubernetes. |
-    | 2026-01-13 | [github.com/mspnp/AzureNamingTool - Azure Naming Tool 🌟](https://github.com/mspnp/AzureNamingTool) | 🔵 medium | Enforces platform engineering discipline by programmatically standardizing resource naming conventions across global enterprise deployments. |
-    | 2025-01-14 | [github.com/azure/mission-critical-online: Welcome to Azure Mission-Critical' Online Reference Implementation](https://github.com/azure/mission-critical-online) | 🔴 critical | Defines the industry gold-standard reference architecture for deploying active-active, zero-downtime microservices on Azure infrastructure. |
-    | 2026-06-02 | [Azure Update 22nd May 2026](https://www.youtube.com/watch?v=pMfG-vYvnv8&feature=youtu.be) | 🟡 high | Highlights critical updates like automatic AKS observability instrumentation and native Cosmos DB support for LangChain AI orchestration. |
-    | 2026-06-02 | [From Prompt to Production: Open in VS Code for Terraform in Azure Copilot](https://techcommunity.microsoft.com/blog/azuretoolsblog/from-prompt-to-production-open-in-vs-code-for-terraform-in-azure-copilot/4494931) | 🔵 medium | Bridges conversational cloud operations and local workflow execution by generating exportable Terraform manifests directly from Azure Copilot. |
-    | 2026-06-02 | [Azure Hub-and-Spoke Generally Available for HCP Vault Dedicated](https://www.hashicorp.com/blog/azure-hub-and-spoke-generally-available-for-hcp-vault-dedicated) | 🟡 high | Bridges cloud-native security and enterprise networking by enabling managed HashiCorp Vault to natively hook into Azure Hub-and-Spoke layouts. |
-
-    **GCP, OCI & Others**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-14 | [github.com/GoogleCloudPlatform/k8s-config-connector: GCP Config Connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) | 🔴 critical | Bridges declarative Kubernetes APIs with Google Cloud resource management, enabling standard GitOps-driven infrastructure provisioning. |
-    | 2026-06-01 | [cloud.google.com: Choose the best way to use and authenticate service accounts on Google Cloud](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) | 🔴 critical | Secures Kubernetes workloads on GCP by leveraging Workload Identity, eliminating the high risk of managing long-lived service account keys. |
-    | 2026-06-13 | [Google Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpacks) | 🟡 high | Automates the generation of secure, OCI-compliant container images directly from source code, standardizing cloud-native build pipelines. |
-    | 2026-05-17 | [github.com/oracle](https://github.com/oracle) | 🟡 high | Hosts the core open-source integrations like Cloud Controller Manager and CSI storage plugins necessary for enterprise Kubernetes on OCI. |
-    | 2026-06-18 | [engineering.mercari.com: Kubernetes based autoscaler for Cloud Spanner](https://engineering.mercari.com/en/blog/entry/20211222-kubernetes-based-spanner-autoscaler) | 🟡 high | Demonstrates advanced cloud-native patterns by utilizing custom Kubernetes controllers to dynamically autoscale Cloud Spanner based on workload metrics. |
-    | 2026-06-14 | [Red Hat's approach to Edge Computing 🌟](https://www.redhat.com/en/solutions/edge-computing-approach) | 🟡 high | Addresses the key operational challenge of deploying cloud-native workloads to resource-constrained edge environments using MicroShift. |
-    | 2026-06-14 | [A hybrid cloud-native DevSecOps pipeline with JFrog Artifactory and GKE on-prem 🌟](https://docs.cloud.google.com/architecture) | 🟡 high | Establishes a comprehensive, secure DevSecOps framework for enterprise environments utilizing GKE on-premises and hybrid cloud architectures. |
-    | 2026-06-01 | [cloud.google.com: Consume services faster, privately and securely - Private Service Connect now in GA](https://cloud.google.com/blog/products/networking/private-service-connect-is-now-generally-available) | 🟡 high | Simplifies multi-tenant and cross-organization cloud networking by facilitating secure, private service connections without complex VPN infrastructure. |
-    | 2026-06-01 | [OpenShift in Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/openshift-container-platform-4x) | 🟡 high | Delivers a fully managed, jointly engineered enterprise OpenShift platform that bridges Red Hat ecosystems with native public cloud infrastructure. |
-    | 2026-06-01 | [cloud.google.com: Microservices architecture on Google Cloud](https://cloud.google.com/blog/topics/developers-practitioners/microservices-architecture-google-cloud) | 🔵 medium | Serves as a vital reference blueprint for engineering teams modeling secure microservices networks using GKE and Anthos Service Mesh. |
-
-    **OpenShift / Red Hat**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-12 | [github.com/openshift/hypershift: HyperShift](https://github.com/openshift/hypershift) | 🔴 critical | HyperShift introduces a major paradigm shift by hosting the OpenShift control plane as containerized workloads, drastically reducing cost and deployment time. |
-    | 2026-06-01 | [Amazon Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift/aws) | 🔴 critical | ROSA is a cornerstone of hybrid-cloud enterprise strategy, delivering a fully-managed, native OpenShift experience directly integrated into AWS. |
-    | 2026-06-08 | [github.com/redhat-cop/gitops-catalog](https://github.com/redhat-cop/gitops-catalog) | 🟡 high | This community-curated collection of GitOps blueprints provides production-ready templates that standardize enterprise application delivery on OpenShift. |
-    | 2026-06-11 | [Red Hat OLM](https://github.com/operator-framework/operator-lifecycle-manager) | 🟡 high | Operator Lifecycle Manager is the foundational orchestrator powering OpenShift's operator-first architecture and automated cluster upgrades. |
-    | 2026-06-14 | [github.com/openshift/installer openshift installer 🌟](https://github.com/openshift/installer) | 🟡 high | The OpenShift Installer is the core engine responsible for automated, production-grade cluster bootstrapping across diverse cloud infrastructures. |
-    | 2026-06-09 | [Machine API](https://github.com/openshift/machine-api-operator/tree/main) | 🟡 high | The Machine API Operator brings cloud-native declarative management to underlying cluster nodes, enabling automated scaling and lifecycle operations. |
-    | 2026-06-01 | [ARO](https://www.redhat.com/en/technologies/cloud-computing/openshift/azure) | 🟡 high | ARO provides a crucial co-engineered, managed OpenShift service on Azure, allowing enterprises to seamlessly run complex containerized workloads. |
-    | 2026-06-01 | [OpenShift Serverless](https://www.redhat.com/en/technologies/cloud-computing/openshift/serverless) | 🟡 high | OpenShift Serverless natively embeds Knative into the platform, providing developers with scale-to-zero capabilities and event-driven automation. |
-    | 2026-06-18 | [OpenShift 4 documentation 🌟](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22) | 🔵 medium | As the official documentation for the latest releases, this resource is the authoritative guide for cluster administrators managing enterprise configurations. |
-    | 2026-06-11 | [GitHub: OKD4](https://github.com/okd-project/okd/blob/master/README.md) | 🔵 medium | OKD4 represents the essential upstream open-source community distribution of OpenShift, serving as the proving ground for cloud-native innovation. |
-
-    **Virtualization & Private Cloud**
-
-    | Date | Resource | Impact | Why It Matters |
-    | :--- | :--- | :---: | :--- |
-    | 2026-06-01 | [ClusterAPI](https://cluster-api.sigs.k8s.io) | 🔴 critical | Enables declarative, API-driven lifecycle management of Kubernetes clusters across diverse virtualization and bare-metal environments. |
-    | 2026-06-14 | [Openshift Container Platform](https://nubenetes.com/openshift) | 🔴 critical | Acts as a market-leading enterprise hybrid platform with native virtualization support for running VMs alongside containers. |
-    | 2026-06-14 | [Rancher: Enterprise management for Kubernetes](https://nubenetes.com/rancher) | 🔴 critical | Simplifies management and operations of multi-cluster Kubernetes deployments on private cloud and bare-metal architectures. |
-    | 2026-06-14 | [**Kubespray**](https://github.com/kubernetes-sigs/kubespray) | 🟡 high | Provides the industry-standard Ansible automation necessary to configure and deploy production-ready clusters on-premises. |
-    | 2026-06-12 | [defenseunicorns/zarf](https://github.com/zarf-dev/zarf) | 🟡 high | Enables highly secure cloud-native application delivery in strictly air-gapped and disconnected private cloud environments. |
-    | 2025-12-05 | [Kubeinit 🌟](https://github.com/kubeinit/kubeinit) | 🟡 high | Automates the deployment of enterprise Kubernetes distributions specifically targeted at libvirt/KVM virtualization infrastructures. |
-    | 2026-05-17 | [**VMware Kubernetes Tanzu**](https://cloud.vmware.com/tanzu) | 🟡 high | Seamlessly integrates cloud-native container orchestration with industry-standard VMware vSphere virtualization infrastructure. |
-    | 2026-06-01 | [Nomad](https://developer.hashicorp.com/nomad) | 🟡 high | Offers a lightweight, operationally simple alternative to Kubernetes for managing virtualized and bare-metal workloads at scale. |
-    | 2026-06-08 | [poseidon/typhoon](https://github.com/poseidon/typhoon) | 🔵 medium | Leverages Terraform to provide a secure, minimalist approach to bootstrapping upstream Kubernetes on bare-metal systems. |
-    | 2026-06-18 | [cncf.io webinar: Deploying Kubernetes to bare metal using cluster API](https://www.cncf.io/online-programs/deploying-kubernetes-to-bare-metal-using-cluster-api) | 🔵 medium | Details the strategic use of Cluster API to bring cloud-native declarative operations directly to bare-metal deployments. |
-
-
 === "Last 12 Months"
-
-    **Kubernetes & Orchestration**
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -691,7 +55,40 @@ search:
     | 2026-06-13 | [Capsule Operator](https://github.com/projectcapsule/capsule) | 🟡 high | It simplifies enterprise platform engineering by aggregating namespaces into secure, multi-tenant virtual clusters with policy enforcement. |
     | 2026-06-13 | [k8gb 🌟](https://github.com/k8gb-io/k8gb) | 🔵 medium | It solves multi-region high availability by implementing a lightweight, Kubernetes-native Global Server Load Balancer using CoreDNS. |
 
-    **Containers & Runtime**
+
+## Containers & Runtime
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-13 | [containerd - An open and reliable container runtime](https://github.com/containerd/containerd) | 🔴 critical | As the industry-standard container runtime for Kubernetes, containerd is foundational for modern cloud-native container execution. |
+    | 2026-06-13 | [runc](https://github.com/opencontainers/runc) | 🔴 critical | It is the canonical, low-level OCI-compliant container runtime that directly spawns and runs container processes across the industry. |
+    | 2026-06-14 | [buildkit](https://docs.docker.com/build) | 🟡 high | Docker's next-generation build engine fundamentally modernizes image creation through concurrent execution and efficient cache management. |
+    | 2026-06-01 | [podman](https://podman.io) | 🟡 high | Provides a widely adopted daemonless and rootless container engine alternative to Docker, enhancing host security. |
+    | 2026-06-01 | [Dapr](https://dapr.io) | 🟡 high | The Distributed Application Runtime simplifies cloud-native microservices development through its modular sidecar architecture. |
+    | 2026-06-01 | [knative.dev](https://knative.dev) | 🟡 high | Serves as the leading Kubernetes-native framework for deploying and scaling request-driven serverless workloads. |
+    | 2026-05-30 | [crun](https://github.com/containers/crun) | 🟡 high | A high-performance, low-memory C-based alternative to runc that is increasingly adopted for modern container orchestration. |
+    | 2026-06-01 | [buildah](https://buildah.io) | 🟡 high | Allows teams to build OCI-compliant container images without a background daemon, significantly reducing pipeline security risks. |
+    | 2026-06-12 | [**GitHub build-push-action**](https://github.com/docker/build-push-action) | 🟡 high | The de facto standard GitHub Action for orchestrating multi-platform Docker and OCI build-and-push automation. |
+    | 2025-12-15 | [dive 🌟](https://github.com/wagoodman/dive) | 🔵 medium | An indispensable CLI tool that helps engineers inspect container image layers to optimize size and minimize attack surfaces. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-13 | [containerd - An open and reliable container runtime](https://github.com/containerd/containerd) | 🔴 critical | It serves as the industry-standard container runtime powering modern Kubernetes clusters globally following Docker shim deprecation. |
+    | 2026-06-14 | [buildkit](https://docs.docker.com/build) | 🔴 critical | It represents a major paradigm shift in container image building, introducing concurrent stages and highly efficient caching. |
+    | 2026-06-01 | [podman](https://podman.io) | 🔴 critical | It drives the enterprise transition toward daemonless, rootless container management and native Kubernetes integration. |
+    | 2026-06-01 | [Dapr](https://dapr.io) | 🟡 high | It provides a highly modular sidecar architecture that standardizes state management and pub/sub for distributed container runtimes. |
+    | 2026-06-01 | [knative.dev](https://knative.dev) | 🟡 high | It is the premier Kubernetes-native platform for orchestrating scale-to-zero serverless container workloads. |
+    | 2026-06-13 | [runc](https://github.com/opencontainers/runc) | 🟡 high | It remains the canonical, industry-standard low-level OCI runtime engine that directly spawns containers on Linux. |
+    | 2026-06-01 | [buildah](https://buildah.io) | 🟡 high | It enables secure, daemonless creation of OCI-compliant container images, dramatically reducing the pipeline security footprint. |
+    | 2026-06-12 | [**GitHub build-push-action**](https://github.com/docker/build-push-action) | 🟡 high | It functions as the ubiquitous enterprise pipeline standard for automating Docker Buildx and multi-platform container image compilation. |
+    | 2026-06-14 | [cert-manager/cert-manager](https://github.com/cert-manager/cert-manager) | 🟡 high | It is the industry-standard tool for automating certificate lifecycles to ensure encrypted communication between cloud-native runtimes. |
+    | 2026-05-30 | [crun](https://github.com/containers/crun) | 🔵 medium | It offers an ultra-fast, low-memory, C-based alternative to runc with native support for advanced Linux namespace features. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -706,7 +103,40 @@ search:
     | 2026-05-30 | [crun](https://github.com/containers/crun) | 🟡 high | An ultra-fast, lightweight OCI runtime written in C that acts as a highly efficient, low-memory replacement for runc in resource-constrained environments. |
     | 2026-06-12 | [**GitHub build-push-action**](https://github.com/docker/build-push-action) | 🟡 high | This utility is the ubiquitous industry standard for automating container image builds and multi-platform distribution within GitHub Actions workflows. |
 
-    **Networking & Service Mesh**
+
+## Networking & Service Mesh
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-12 | [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api) | 🔴 critical | Establishes the next-generation standard for expressive, role-oriented, and extensible routing and ingress configurations in Kubernetes. |
+    | 2026-06-14 | [github.com: Istio](https://github.com/istio/istio) | 🔴 critical | The leading enterprise-grade service mesh that defines how modern cloud-native architectures secure, control, and observe traffic. |
+    | 2026-06-01 | [Linkerd](https://linkerd.io) | 🔴 critical | The premier Rust-based, CNCF-graduated service mesh that delivers security and performance with minimal operational complexity. |
+    | 2026-05-17 | [github.com/containernetworking 🌟](https://github.com/containernetworking) | 🔴 critical | The foundational specification and reference plugins that underly all modern cloud-native container networking solutions. |
+    | 2026-06-14 | [Envoy Gateway](https://github.com/envoyproxy/gateway) | 🟡 high | Unifies edge proxy management by bringing the official Envoy-backed implementation of the Kubernetes Gateway API. |
+    | 2026-06-02 | [Consul 2.0 improves flexibility, control, and scalability](https://www.hashicorp.com/blog/consul-20-improves-flexibility-control-and-scalability) | 🟡 high | Introduces significant architectural advancements, multi-port service mesh capabilities, and enhanced scale for enterprise service networking. |
+    | 2026-06-14 | [NodeLocal DNSCache](https://github.com/kubernetes/enhancements) | 🟡 high | Significantly improves Kubernetes DNS performance and reliability by running a caching agent on every node to bypass conntrack limits. |
+    | 2026-06-12 | [github.com: kiali](https://github.com/kiali/kiali) | 🟡 high | Provides critical real-time observability, interactive topology mapping, and configuration validation for Istio-based service meshes. |
+    | 2026-06-01 | [Meshery.io:](https://meshery.io) | 🟡 high | Empowers platform engineers to manage, benchmark, and design configurations across diverse service mesh topologies within a unified control plane. |
+    | 2026-06-01 | [editor.cilium.io 🌟](https://editor.networkpolicy.io) | 🔵 medium | Simplifies zero-trust security operations by providing an interactive visual playground to author and debug complex Kubernetes Network Policies. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [github.com: Istio](https://github.com/istio/istio) | 🔴 critical | As the industry-standard service mesh, Istio defines the state of the art for zero-trust security, traffic management, and observability in enterprise Kubernetes. |
+    | 2026-06-12 | [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api) | 🔴 critical | This official, highly expressive next-generation routing specification fundamentally replaces the legacy Ingress resource to unify edge and service-mesh configurations. |
+    | 2026-05-17 | [github.com/containernetworking 🌟](https://github.com/containernetworking) | 🔴 critical | This repository hosts the foundational CNI specification and core plugins that govern container networking across the entire cloud-native ecosystem. |
+    | 2026-06-01 | [Linkerd](https://linkerd.io) | 🔴 critical | Linkerd provides an ultra-lightweight, Rust-powered, and CNCF-graduated alternative to heavy Envoy-based service meshes with native automatic mTLS. |
+    | 2026-06-14 | [Envoy Gateway](https://github.com/envoyproxy/gateway) | 🟡 high | It unifies ingress controller standards by bringing the Gateway API directly to the Envoy Proxy, simplifying cloud-native edge architectures. |
+    | 2026-06-02 | [Consul 2.0 improves flexibility, control, and scalability](https://www.hashicorp.com/blog/consul-20-improves-flexibility-control-and-scalability) | 🟡 high | The release of Consul 2.0 introduces multi-port service mesh support and multi-cloud security advancements, strengthening its place in enterprise architectures. |
+    | 2026-06-14 | [NodeLocal DNSCache](https://github.com/kubernetes/enhancements) | 🟡 high | This architectural enhancement eliminates DNS performance bottlenecks and latency spikes at scale by caching queries locally on every cluster node. |
+    | 2026-06-14 | [NetBox IPAM 🌟](https://github.com/netbox-community/netbox) | 🟡 high | NetBox serves as the industry-standard single source of truth for programmable IP address management (IPAM) and infrastructure automation. |
+    | 2026-06-01 | [Meshery.io:](https://meshery.io) | 🔵 medium | This CNCF tool simplifies multi-mesh operations by enabling unified performance benchmarking, conformance testing, and design across diverse service meshes. |
+    | 2026-06-08 | [Flannel](https://github.com/flannel-io/flannel) | 🔵 medium | Flannel remains a highly stable, lightweight, and foundational CNI solution widely used for simple Kubernetes networking installations. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -721,7 +151,40 @@ search:
     | 2026-06-01 | [Meshery.io:](https://meshery.io) | 🟡 high | As the CNCF multi-mesh manager, Meshery standardizes performance benchmarking, conformance testing, and design across diverse service mesh implementations. |
     | 2026-06-12 | [github.com: kiali](https://github.com/kiali/kiali) | 🟡 high | Kiali is the leading visualization dashboard for Istio, allowing platform engineers to interactively monitor, validate, and troubleshoot complex service mesh topologies. |
 
-    **Architecture & Microservices**
+
+## Architecture & Microservices
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-10 | [Awesome microservices](https://github.com/mfornos/awesome-microservices) | 🔴 critical | A premier comprehensive directory detailing microservices design patterns, API gateways, and distributed consensus engines necessary for building decoupled systems. |
+    | 2026-06-08 | [rootsongjc/awesome-cloud-native 🌟](https://github.com/rootsongjc/awesome-cloud-native) | 🔴 critical | Provides an extensive, systematic mapping of the CNCF landscape, service meshes, and dynamic storage configurations vital for platform architects. |
+    | 2026-06-01 | [developer.hashicorp.com 🌟](https://developer.hashicorp.com) | 🔴 critical | The consolidated technical documentation hub for HashiCorp tools (Terraform, Consul, Vault, Nomad) which define modern multi-cloud infrastructure architectures. |
+    | 2026-05-30 | [clusterpedia-io/clusterpedia 🌟](https://github.com/clusterpedia-io/clusterpedia) | 🟡 high | An innovative open-source search engine that solves multi-cluster discovery issues by synchronizing global Kubernetes resources into a centralized database. |
+    | 2022-11-10 | [Awesome API Management Tools](https://github.com/mailtoharshit/Awesome-Api-Management-Tools) | 🟡 high | A dedicated compilation of API gateway engines and lifecycle management tools crucial for establishing robust, API-first microservices communication patterns. |
+    | 2026-04-25 | [github.com/calvin-puram: Awesome Kubernetes Operator Resources](https://github.com/calvin-puram/awesome-kubernetes-operator-resources) | 🟡 high | A comprehensive index of operator SDKs and controller patterns essential for building self-healing, stateful applications on top of Kubernetes. |
+    | 2026-05-25 | [anderseknert/awesome-opa 🌟](https://github.com/open-policy-agent/awesome-opa) | 🟡 high | Focuses on Open Policy Agent (OPA) integrations, empowering cloud architects to inject declarative security and governance policy-as-code into microservices pipelines. |
+    | 2026-05-23 | [github.com/lukemurraynz/awesome-azure-architecture 🌟](https://github.com/lukemurraynz/awesome-azure-architecture) | 🟡 high | An exhaustive collection of enterprise landing zones and reference architecture designs crucial for bootstrapping highly compliant Azure cloud environments. |
+    | 2026-06-09 | [mingrammer/diagrams](https://github.com/mingrammer/diagrams) | 🔵 medium | An industry-standard Python framework that enables architects to model and version-control complex cloud system topologies directly as code. |
+    | 2026-06-14 | [Terraform Kubernetes Boilerplates 🌟](https://nubenetes.com/terraform) | 🟡 high | Provides pre-tested, production-ready Terraform templates to quickly bootstrap secure network topologies and managed Kubernetes services across major cloud providers. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-10 | [Awesome microservices](https://github.com/mfornos/awesome-microservices) | 🟡 high | Provides a definitive directory of microservices patterns, API gateways, and event-streaming components vital for building decoupled systems. |
+    | 2026-01-04 | [Awesome Scalability](https://github.com/binhnguyennus/awesome-scalability) | 🔴 critical | Offers foundational structural design patterns for building scalable, highly available backend architectures and microservices environments. |
+    | 2026-06-08 | [rootsongjc/awesome-cloud-native 🌟](https://github.com/rootsongjc/awesome-cloud-native) | 🟡 high | Systematically maps the CNCF ecosystem, providing cloud-native architects with curated guidelines on service meshes, logging, and storage. |
+    | 2026-05-25 | [anderseknert/awesome-opa 🌟](https://github.com/open-policy-agent/awesome-opa) | 🟡 high | Enables policy-as-code enforcement across Kubernetes and microservices using Open Policy Agent (OPA), a graduated CNCF project. |
+    | 2026-04-25 | [github.com/calvin-puram: Awesome Kubernetes Operator Resources](https://github.com/calvin-puram/awesome-kubernetes-operator-resources) | 🟡 high | Acts as a premier reference for developing Kubernetes Operators to automate complex, stateful application deployments. |
+    | 2026-05-30 | [clusterpedia-io/clusterpedia 🌟](https://github.com/clusterpedia-io/clusterpedia) | 🟡 high | Introduces a highly novel multi-cluster search engine that synchronizes Kubernetes resources across environments to simplify management. |
+    | 2026-06-09 | [mingrammer/diagrams](https://github.com/mingrammer/diagrams) | 🟡 high | Shifts the documentation paradigm by enabling architects to write complex cloud infrastructure diagrams dynamically as Python code. |
+    | 2022-11-10 | [Awesome API Management Tools](https://github.com/mailtoharshit/Awesome-Api-Management-Tools) | 🔵 medium | Crucial for microservices governance, cataloging tools that manage API gateways, design portals, and OpenAPI specifications. |
+    | 2026-06-14 | [Terraform Kubernetes Boilerplates 🌟](https://nubenetes.com/terraform) | 🟡 high | Provides enterprise-grade, pre-tested Terraform configurations for establishing secure and standardized public cloud Kubernetes infrastructure. |
+    | 2026-06-10 | [Awesome Compose 🌟](https://github.com/docker/awesome-compose) | 🔵 medium | Offers official, curated declarative multi-container topology configurations essential for orchestrating localized microservice stacks. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -736,7 +199,40 @@ search:
     | 2022-11-10 | [Awesome API Management Tools](https://github.com/mailtoharshit/Awesome-Api-Management-Tools) | 🔵 medium | Essential directory for selecting API gateways and design portals crucial to securing and orchestrating inter-service communication. |
     | 2026-06-14 | [Awesome Docker 🌟](https://github.com/veggiemonk/awesome-docker) | 🟡 high | The premier community collection of container runtimes, base images, and hardening configurations fundamental to packaging microservices safely. |
 
-    **Data, Messaging & Storage**
+
+## Data, Messaging & Storage
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [strimzi.io](https://strimzi.io) | 🔴 critical | The premier CNCF-backed project that makes running and managing production Apache Kafka clusters on Kubernetes seamless via the Operator pattern. |
+    | 2026-06-12 | [github.com/vmware-tanzu/velero](https://github.com/velero-io/velero) | 🔴 critical | The industry-standard open-source solution for Kubernetes disaster recovery, backing up both cluster state and persistent volume data. |
+    | 2026-06-01 | [Longhorn](https://longhorn.io) | 🔴 critical | A graduated CNCF project offering highly reliable, distributed block storage built natively and lightweight for Kubernetes environments. |
+    | 2026-06-01 | [min.io](https://www.min.io) | 🔴 critical | The leading S3-compatible high-performance object storage platform designed specifically for Kubernetes and private cloud deployments. |
+    | 2026-06-01 | [**Debezium**:](https://debezium.io) | 🟡 high | The de facto standard for log-based Change Data Capture (CDC), enabling real-time database streaming in modern event-driven architectures. |
+    | 2026-06-01 | [Apache Flink](https://flink.apache.org) | 🟡 high | The industry-standard framework for high-throughput, stateful stream processing on real-time event logs with robust exactly-once guarantees. |
+    | 2026-06-01 | [Redpanda 🌟](https://www.redpanda.com) | 🟡 high | A highly innovative, JVM-free Kafka alternative written in C++ that significantly reduces infrastructure footprint and operational complexity. |
+    | 2026-06-12 | [Zalando Postgres Operator](https://github.com/zalando/postgres-operator) | 🟡 high | An enterprise-grade, production-proven operator that automates the deployment and high-availability management of PostgreSQL on Kubernetes. |
+    | 2026-06-01 | [OpenEBS](https://openebs.io) | 🟡 high | A prominent Container Attached Storage (CAS) platform that simplifies turning local disks into dynamic persistent volumes for stateful applications. |
+    | 2026-06-14 | [github.com/kubernetes-sigs: Local Persistence Volume Static Provisioner' 🌟](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner) | 🟡 high | An official Kubernetes-SIG project that automates local storage provisioning, enabling latency-sensitive databases to achieve maximum raw NVMe performance. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Apache Kafka](https://kafka.apache.org) | 🔴 critical | The de facto industry standard for high-throughput, fault-tolerant distributed event streaming. |
+    | 2026-06-01 | [strimzi.io](https://strimzi.io) | 🔴 critical | The premier cloud-native operator for running and managing production-grade Apache Kafka clusters on Kubernetes. |
+    | 2026-06-01 | [Longhorn](https://longhorn.io) | 🔴 critical | A graduated CNCF project offering robust, easy-to-use, and lightweight distributed block storage designed specifically for Kubernetes. |
+    | 2026-06-01 | [min.io](https://www.min.io) | 🔴 critical | The leading high-performance, S3-compatible object storage platform optimized for native Kubernetes deployments. |
+    | 2026-06-01 | [Redpanda 🌟](https://www.redpanda.com) | 🟡 high | Re-engineers event streaming in C++ to achieve ultra-low latency and JVM-free operations while maintaining full Kafka API compatibility. |
+    | 2026-06-12 | [github.com/vmware-tanzu/velero](https://github.com/velero-io/velero) | 🔴 critical | The standard open-source utility for backing up, restoring, and migrating Kubernetes cluster resources and persistent volumes. |
+    | 2026-06-01 | [**Debezium**:](https://debezium.io) | 🟡 high | The industry-standard distributed platform for log-based Change Data Capture (CDC) to enable real-time database event streams. |
+    | 2026-06-01 | [Apache Flink](https://flink.apache.org) | 🟡 high | The leading framework for processing stateful real-time data streams with millisecond latency and robust fault tolerance. |
+    | 2026-06-12 | [Zalando Postgres Operator](https://github.com/zalando/postgres-operator) | 🟡 high | Simplifies day-2 operations for mission-critical PostgreSQL databases on Kubernetes by automating high-availability, scaling, and backups. |
+    | 2026-06-01 | [OpenEBS](https://openebs.io) | 🟡 high | A highly flexible, cloud-native container-attached storage system that transforms local storage into dynamic persistent volumes. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -751,7 +247,40 @@ search:
     | 2026-06-01 | [Redpanda 🌟](https://www.redpanda.com) | 🟡 high | Disrupts the event streaming landscape by offering a C++ engineered, JVM-free, Kafka-compatible platform that slashes operational overhead. |
     | 2025-06-01 | [Kasten](https://www.veeam.com/products/cloud/kubernetes-data-protection.html) | 🟡 high | The leading enterprise-grade data protection and disaster recovery platform built natively to secure complex stateful Kubernetes applications. |
 
-    **AI & Agents**
+
+## AI & Agents
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-18 | [antigravity.google: Google Antigravity Agentic Platform](https://antigravity.google) | 🔴 critical | It directly bridges the gap between local agent prototypes and production-grade Google Kubernetes Engine (GKE) deployments for stateful AI agents. |
+    | 2026-06-14 | [vLLM on Kubernetes](https://github.com/vllm-project/vllm) | 🔴 critical | It provides the definitive standard for hosting highly optimized, memory-efficient LLM serving engines using PagedAttention on Kubernetes. |
+    | 2026-06-18 | [docs.anthropic.com: Claude Code CLI](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | 🔴 critical | Anthropic's official tool fundamentally shifts developer workflows by bringing autonomous agentic coding and execution directly into the terminal. |
+    | 2026-06-02 | [Announcing Claude Managed Agents on Cloudflare](https://blog.cloudflare.com/claude-managed-agents) | 🟡 high | It establishes a secure, cloud-native sandboxed execution plane for running autonomous AI agents on serverless edge infrastructure. |
+    | 2026-06-07 | [GitHub MCP Server](https://github.com/modelcontextprotocol/servers) | 🟡 high | It standardizes the Model Context Protocol (MCP) to enable secure, structured communication and tool usage for AI agents across different host environments. |
+    | 2026-06-13 | [LocalAI](https://github.com/mudler/LocalAI) | 🟡 high | It enables secure, private, and fully self-hosted deployments of OpenAI-compatible LLM APIs and agent backends on local and Kubernetes infrastructure. |
+    | 2026-06-18 | [cursor.com: Cursor AI Code Editor](https://cursor.com) | 🟡 high | It is the premier AI-first IDE driving widespread developer adoption of multi-file agentic code generation and editor workflows. |
+    | 2026-06-10 | [Google Agents CLI](https://github.com/google/agents-cli) | 🟡 high | An official command-line interface from Google that leverages MCP and Gemini models to orchestrate automated, agentic tasks. |
+    | 2026-06-02 | [OpenAI and Dell Technologies partner to bring Codex to hybrid and on-premises enterprise environments](https://openai.com/index/dell-codex-enterprise-partnership) | 🟡 high | It accelerates enterprise adoption of advanced coding agents by bridging OpenAI's developer ecosystem with on-premises and hybrid cloud environments. |
+    | 2026-06-14 | [OpenOps: No-Code FinOps Automation Platform with AI](https://github.com/openops-cloud/openops) | 🔵 medium | It directly connects Kubernetes metric endpoints with AI optimization to automate cloud cost reductions and sizing adjustments. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [vLLM on Kubernetes](https://github.com/vllm-project/vllm) | 🔴 critical | It standardizes high-performance, memory-efficient LLM serving via vLLM on Kubernetes clusters, directly bridging cloud-native infrastructure with AI workloads. |
+    | 2026-06-18 | [antigravity.google: Google Antigravity Agentic Platform](https://antigravity.google) | 🔴 critical | This unified platform and SDK allows developers to seamlessly transition stateful AI agents from local prototypes to production-grade Google Kubernetes Engine deployments. |
+    | 2026-06-02 | [Announcing Claude Managed Agents on Cloudflare](https://blog.cloudflare.com/claude-managed-agents) | 🔴 critical | The partnership provides a secure, sandboxed execution plane at the cloud edge for hosting and running autonomous agent workflows safely. |
+    | 2026-06-18 | [docs.anthropic.com: Claude Code CLI](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) | 🟡 high | Anthropic's official CLI agent transforms developer workflows by autonomously interacting with codebases, running tests, and managing git operations directly. |
+    | 2026-06-18 | [cursor.com: Cursor AI Code Editor](https://cursor.com) | 🟡 high | As the leading AI-first code editor, its multi-file agentic code generation features have fundamentally changed how software engineering teams write and refactor code daily. |
+    | 2026-06-07 | [GitHub MCP Server](https://github.com/modelcontextprotocol/servers) | 🟡 high | This repository establishes critical development standards for the Model Context Protocol (MCP), enabling structured, secure communication between host agents and tools. |
+    | 2026-06-13 | [LocalAI](https://github.com/mudler/LocalAI) | 🟡 high | It provides a crucial self-hosted, OpenAI-compatible API gateway that enables teams to run private, local LLMs within secure cloud-native environments. |
+    | 2025-06-01 | [CAST AI](https://cast.ai) | 🟡 high | By utilizing real-time AI algorithms to automate resource scaling and spot instance configuration, it dramatically reduces cloud spend for managed Kubernetes clusters. |
+    | 2026-06-10 | [Google Agents CLI](https://github.com/google/agents-cli) | 🟡 high | Google's official CLI leverages the Model Context Protocol to streamline the design, testing, and deployment of complex agentic task orchestration workflows. |
+    | 2026-06-14 | [OpenOps: No-Code FinOps Automation Platform with AI](https://github.com/openops-cloud/openops) | 🔵 medium | It integrates AI-driven cost optimization directly with Kubernetes metrics, providing a no-code FinOps solution to automate resource rightsizing. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -766,7 +295,40 @@ search:
     | 2026-06-13 | [LocalAI](https://github.com/mudler/LocalAI) | 🟡 high | Enables teams to host fully OpenAI-compatible API gateways locally and securely on their own Kubernetes infrastructure. |
     | 2026-06-02 | [Announcing Claude Managed Agents on Cloudflare](https://blog.cloudflare.com/claude-managed-agents) | 🔴 critical | Provides a crucial, secure sandboxed execution plane for autonomous workflows using serverless Cloudflare Workers. |
 
-    **MLOps & Data Science**
+
+## MLOps & Data Science
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Ray](https://docs.ray.io/en/latest) | 🔴 critical | Ray is the industry-standard distributed compute framework essential for scaling heavy AI training and LLM workloads. |
+    | 2026-05-17 | [openai.com: Scaling Kubernetes to 7,500 nodes 🌟](https://openai.com/research/scaling-kubernetes-to-7500-nodes) | 🔴 critical | OpenAI's scaling insights provide the ultimate blueprint for running massive-scale machine learning workloads on Kubernetes. |
+    | 2026-06-13 | [github.com/Netflix/metaflow 🌟](https://github.com/Netflix/metaflow) | 🟡 high | Metaflow bridges the gap between local data science development and scalable cloud-native production infrastructure. |
+    | 2026-05-19 | [github.com/meta-llama/llama-recipes](https://github.com/meta-llama/llama-cookbook) | 🟡 high | Meta's official recipes establish standardized best practices for parameter-efficient fine-tuning and LLM optimization. |
+    | 2026-06-08 | [rubrix](https://github.com/argilla-io/argilla) | 🟡 high | Argilla addresses the critical LLM challenge of data curation and continuous human-in-the-loop alignment. |
+    | 2026-06-02 | [SilverTorch: Index as Model — A New Retrieval Paradigm for Recommendation Systems](https://engineering.fb.com/2026/05/26/ml-applications/silvertorch-index-as-model-new-retrieval-paradigm-recommendation-systems) | 🟡 high | SilverTorch redefines recommendation engine architectures by unifying retrieval and scoring into a single GPU-optimized model. |
+    | 2026-06-18 | [mikeroyal/Kubernetes-Guide: Machine Learning 🌟](https://github.com/mikeroyal/Kubernetes-Guide/blob/main/README.md) | 🟡 high | This manual serves as an indispensable reference mapping the complex landscape of running machine learning workloads on Kubernetes. |
+    | 2026-05-17 | [medium.com/workday-engineering: Implementing a Fully Automated Sharding' Strategy on Kubernetes for Multi-tenanted Machine Learning Applications](https://medium.com/workday-engineering/implementing-a-fully-automated-sharding-strategy-on-kubernetes-for-multi-tenanted-machine-learning-4371c48122ae) | 🟡 high | It outlines a highly sophisticated, real-world architectural pattern for managing multi-tenant ML applications using Kubernetes sharding. |
+    | 2026-05-17 | [medium.com/@bchenjh: Distributed full fine-tuning of Llama2 on Kubernetes](https://medium.com/@bchenjh/full-fine-tuning-of-llama2-on-kubernetes-a983e1eb2259) | 🟡 high | This guide provides a practical, cloud-native blueprint for running distributed LLM fine-tuning operations on Kubernetes. |
+    | 2026-05-21 | [tensorchord/envd: Reproducible development environment for AI/ML 🌟](https://github.com/tensorchord/envd) | 🔵 medium | Envd solves the notorious ML pain point of environment reproducibility by generating isolated, CUDA-ready dev containers from Python declarations. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Ray](https://docs.ray.io/en/latest) | 🔴 critical | As the dominant distributed execution framework for AI, Ray is foundational for scaling compute-heavy workloads across cloud-native environments. |
+    | 2026-05-17 | [openai.com: Scaling Kubernetes to 7,500 nodes 🌟](https://openai.com/research/scaling-kubernetes-to-7500-nodes) | 🔴 critical | This landmark case study provides invaluable infrastructure blueprints for scaling Kubernetes to handle massive, state-of-the-art AI/ML training workloads. |
+    | 2026-06-13 | [github.com/Netflix/metaflow 🌟](https://github.com/Netflix/metaflow) | 🔴 critical | Netflix's production-proven framework seamlessly bridges local data science development with enterprise-scale cloud infrastructure and orchestration. |
+    | 2026-05-19 | [github.com/meta-llama/llama-recipes](https://github.com/meta-llama/llama-cookbook) | 🟡 high | Provides industry-standard templates for parameter-efficient fine-tuning and optimization, defining modern LLMOps deployment patterns. |
+    | 2026-05-17 | [medium.com/workday-engineering: Implementing a Fully Automated Sharding' Strategy on Kubernetes for Multi-tenanted Machine Learning Applications](https://medium.com/workday-engineering/implementing-a-fully-automated-sharding-strategy-on-kubernetes-for-multi-tenanted-machine-learning-4371c48122ae) | 🟡 high | Solves critical multi-tenancy and resource isolation challenges for ML applications at enterprise scale using native Kubernetes sharding. |
+    | 2026-06-18 | [mikeroyal/Kubernetes-Guide: Machine Learning 🌟](https://github.com/mikeroyal/Kubernetes-Guide/blob/main/README.md) | 🟡 high | Serves as an essential technical reference mapping out configurations and architectural patterns for running diverse ML workloads on Kubernetes. |
+    | 2026-05-17 | [medium.com/@bchenjh: Distributed full fine-tuning of Llama2 on Kubernetes](https://medium.com/@bchenjh/full-fine-tuning-of-llama2-on-kubernetes-a983e1eb2259) | 🟡 high | Demonstrates a practical, cloud-native pattern for executing complex, distributed LLM fine-tuning directly on Kubernetes clusters. |
+    | 2026-06-08 | [rubrix](https://github.com/argilla-io/argilla) | 🟡 high | A critical open-source platform that enables human-in-the-loop data curation, which is essential for continuous alignment of modern generative AI models. |
+    | 2026-05-21 | [tensorchord/envd: Reproducible development environment for AI/ML 🌟](https://github.com/tensorchord/envd) | 🔵 medium | Simplifies the ML-to-cloud transition by automatically packaging Python declarations into highly reproducible, CUDA-enabled containers. |
+    | 2026-05-17 | [medium.com/bakdata: Scalable Machine Learning with Kafka Streams and KServe](https://medium.com/bakdata/scalable-machine-learning-with-kafka-streams-and-kserve-85308858d867) | 🔵 medium | Showcases a robust, event-driven architecture for scaling real-time model inference using KServe and Kafka on Kubernetes. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -781,7 +343,40 @@ search:
     | 2026-06-02 | [SilverTorch: Index as Model — A New Retrieval Paradigm for Recommendation Systems](https://engineering.fb.com/2026/05/26/ml-applications/silvertorch-index-as-model-new-retrieval-paradigm-recommendation-systems) | 🟡 high | Meta's paradigm-shifting architecture that consolidates vector retrieval, filtering, and scoring into a single GPU-optimized PyTorch model. |
     | 2026-05-25 | [github.com/XuehaiPan/nvitop 🌟](https://github.com/XuehaiPan/nvitop) | 🔵 medium | An essential, interactive terminal-based GPU monitoring tool that serves as a modern, real-time replacement for nvidia-smi. |
 
-    **Python, Java & Developer Ecosystem**
+
+## Python, Java & Developer Ecosystem
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [metalbear-co/mirrord](https://github.com/metalbear-co/mirrord) | 🔴 critical | Plugs local processes directly into remote Kubernetes namespaces to streamline local development without remote deployments. |
+    | 2026-06-14 | [Ruff](https://github.com/astral-sh/ruff) | 🟡 high | Revolutionizes Python development by providing an extremely fast, Rust-powered linter and formatter that dramatically reduces CI loop times. |
+    | 2026-06-14 | [testcontainers-spring-boot 🌟](https://github.com/PlaytikaOSS/testcontainers-spring-boot) | 🟡 high | Streamlines Java integration testing by automatically managing Docker container lifecycles directly within JUnit executions. |
+    | 2026-06-13 | [github.com/spring-projects: springboot enables these probes automatically when running in k8s](https://github.com/spring-projects/spring-boot#L73) | 🟡 high | Automatically integrates Spring Boot applications with Kubernetes by auto-detecting hosting environments and configuring Liveness/Readiness probes. |
+    | 2026-06-13 | [pydantic/pydantic](https://github.com/pydantic/pydantic) | 🟡 high | Delivers ultra-fast, Rust-backed type validation that has become the de facto standard for building robust Python services. |
+    | 2026-06-12 | [apache/maven-mvnd](https://github.com/apache/maven-mvnd) | 🟡 high | Drastically reduces Java compilation times using a persistent background build daemon to cache hot-spots and configurations. |
+    | 2026-06-12 | [github: Spring Cloud Kubernetes 🌟](https://github.com/spring-cloud/spring-cloud-kubernetes) | 🟡 high | Enables Spring Cloud applications to natively discover and interact with Kubernetes platform features like ConfigMaps, Secrets, and services. |
+    | 2026-06-12 | [github.com/bloomberg/memray 🌟🌟](https://github.com/bloomberg/memray) | 🟡 high | Provides an advanced memory profiler for Python microservices to track allocations and resolve performance bottlenecks. |
+    | 2026-06-01 | [quarkus.io](https://quarkus.io) | 🔴 critical | Optimizes Java for Kubernetes and serverless environments by offering lightning-fast startup times and low memory footprints via GraalVM. |
+    | 2026-05-17 | [Kubernetes (by Microsoft)](https://marketplace.visualstudio.com/items?itemName=ms-kubernetes-tools.vscode-kubernetes-tools) | 🟡 high | Acts as the definitive visual tool for cloud-native developers to manage clusters and debug microservices directly from VS Code. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [metalbear-co/mirrord](https://github.com/metalbear-co/mirrord) | 🟡 high | It revolutionizes cloud-native debugging by letting developers run local processes seamlessly inside remote Kubernetes namespaces without image rebuilds. |
+    | 2026-06-14 | [Ruff](https://github.com/astral-sh/ruff) | 🔴 critical | It has become the de facto standard for Python linting and formatting, drastically reducing CI/CD runtimes due to its high-performance Rust implementation. |
+    | 2026-06-14 | [testcontainers-spring-boot 🌟](https://github.com/PlaytikaOSS/testcontainers-spring-boot) | 🟡 high | It standardizes enterprise integration testing in Java by automating the local lifecycle of Docker dependencies like databases and message brokers directly within JUnit tests. |
+    | 2026-06-13 | [github.com/spring-projects: springboot enables these probes automatically when running in k8s](https://github.com/spring-projects/spring-boot#L73) | 🟡 high | It simplifies Kubernetes deployments by automatically detecting the host platform and exposing cloud-native liveness and readiness probes out of the box. |
+    | 2026-06-13 | [pydantic/pydantic](https://github.com/pydantic/pydantic) | 🔴 critical | As the industry standard for Python data validation, its high-performance Rust engine (V2) enforces type safety and schema definitions at scale in microservices. |
+    | 2026-06-12 | [apache/maven-mvnd](https://github.com/apache/maven-mvnd) | 🟡 high | It significantly accelerates Java development loops by using a persistent background daemon to eliminate Maven compilation overhead. |
+    | 2026-06-12 | [github: Spring Cloud Kubernetes 🌟](https://github.com/spring-cloud/spring-cloud-kubernetes) | 🟡 high | It bridges the gap between Java microservices and Kubernetes infrastructure by mapping ConfigMaps and Secrets directly to the Spring environment. |
+    | 2026-06-12 | [github.com/bloomberg/memray 🌟🌟](https://github.com/bloomberg/memray) | 🟡 high | It provides high-fidelity memory profiling for Python applications, which is critical for debugging resource leaks in containerized microservices. |
+    | 2026-06-01 | [quarkus.io](https://quarkus.io) | 🔴 critical | It redefines modern Java for the cloud-native era by optimizing boot times and memory usage specifically for GraalVM and Kubernetes environments. |
+    | 2026-06-01 | [Spring Cloud](https://spring.io/projects/spring-cloud) | 🔴 critical | It remains the foundational standard for orchestrating distributed systems patterns, routing, and configuration management across enterprise Java microservices. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -796,7 +391,40 @@ search:
     | 2026-06-01 | [quarkus.io](https://quarkus.io) | 🔴 critical | It delivers a highly optimized Java framework designed specifically for GraalVM, dramatically reducing memory footprint and startup times in Kubernetes. |
     | 2026-06-01 | [Spring Cloud](https://spring.io/projects/spring-cloud) | 🟡 high | It remains the foundational standard library for orchestrating distributed systems and microservices patterns within the enterprise Java ecosystem. |
 
-    **Linux & System Foundations**
+
+## Linux & System Foundations
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [redhat.com: World domination with cgroups part 8: down and dirty with cgroup v2](https://www.redhat.com/en/blog/world-domination-cgroups-part-8-down-and-dirty-cgroup-v2) | 🔴 critical | Directly impacts container and Kubernetes node resource isolation by detailing cgroup v2 mechanics and Memory Pressure Stalls (PSI). |
+    | 2026-06-13 | [bpftrace](https://github.com/bpftrace/bpftrace) | 🟡 high | Provides a high-level tracing language leveraging eBPF, revolutionizing modern system diagnostics and kernel-level performance debugging. |
+    | 2026-06-01 | [LWN.net](https://lwn.net) | 🟡 high | Remains the gold standard for tracking upstream Linux kernel evolution and structural operating system paradigms essential for platform engineering. |
+    | 2024-04-30 | [termshark](https://github.com/gcla/termshark) | 🟡 high | Enables interactive, terminal-based network packet analysis on headless servers and Kubernetes nodes over remote SSH connections. |
+    | 2026-03-05 | [How-To Secure A Linux Server](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server) | 🟡 high | Provides an actionable, step-by-step framework for securing and hardening enterprise-grade Linux servers against modern threats. |
+    | 2026-06-01 | [abarrak.gitbook.io: Linux SysOps Handbook 🌟](https://abarrak.gitbook.io/linux-sysops-handbook) | 🟡 high | Acts as an essential, high-density operational handbook for on-call systems engineers diagnosing complex performance and networking issues. |
+    | 2026-01-05 | [github: Safe ways to do things in bash](https://github.com/anordal/shellharden/blob/master/how_to_do_things_safely_in_bash.md) | 🟡 high | Serves as an authoritative style manual to prevent common script failures, scoping bugs, and safety issues in systems automation. |
+    | 2026-06-01 | [sysadminxpert.com: How to watch real time TCP and UDP ports on Linux (netstat & ss) 🌟](https://sysadminxpert.com/how-to-watch-real-time-tcp-and-udp-ports-on-linux) | 🔵 medium | Compares key low-level diagnostic tools vital for verifying active port binds, ingress routing, and socket states on Linux hosts. |
+    | 2026-06-01 | [**curl command**: Understanding the Hidden Powers of curl](https://nordicapis.com/understanding-the-hidden-powers-of-curl) | 🔵 medium | Deepens technical understanding of curl for raw TCP manipulation and custom HTTP requests, which is crucial for cloud-native API troubleshooting. |
+    | 2026-05-31 | [oilshell: Alternative shells](https://github.com/oils-for-unix/oils/wiki/Alternative-Shells) | 🔵 medium | Evaluates next-generation shells that attempt to replace legacy bash with safer parsing, structured JSON pipelines, and robust error handling. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [redhat.com: World domination with cgroups part 8: down and dirty with cgroup v2](https://www.redhat.com/en/blog/world-domination-cgroups-part-8-down-and-dirty-cgroup-v2) | 🔴 critical | cgroup v2 is the foundational resource control layer enabling memory pressure stalls and unified resource management in modern container engines. |
+    | 2026-06-13 | [bpftrace](https://github.com/bpftrace/bpftrace) | 🔴 critical | eBPF-driven bpftrace provides safe, high-performance, dynamic kernel and userspace tracing essential for cloud-native performance analysis. |
+    | 2026-03-05 | [How-To Secure A Linux Server](https://github.com/imthenachoman/How-To-Secure-A-Linux-Server) | 🟡 high | Provides a comprehensive, production-grade security blueprint indispensable for hardening enterprise Linux node installations. |
+    | 2024-04-30 | [termshark](https://github.com/gcla/termshark) | 🟡 high | Enables interactive, packet-level network debugging over remote SSH and container network namespaces without exporting massive PCAPs. |
+    | 2026-01-05 | [github: Safe ways to do things in bash](https://github.com/anordal/shellharden/blob/master/how_to_do_things_safely_in_bash.md) | 🟡 high | Establishes bulletproof shell scripting standards to prevent silent failures and security vulnerabilities in critical system and container entrypoints. |
+    | 2026-06-13 | [zx](https://github.com/google/zx) | 🟡 high | Modernizes infrastructure glue code by providing a safe, JavaScript-based execution engine that replaces fragile traditional shell scripts. |
+    | 2026-06-01 | [sysadminxpert.com: How to watch real time TCP and UDP ports on Linux (netstat & ss) 🌟](https://sysadminxpert.com/how-to-watch-real-time-tcp-and-udp-ports-on-linux) | 🔵 medium | Provides critical comparative diagnostics of modern socket tracking, essential for debugging routing, firewalls, and networking on Linux hosts. |
+    | 2026-06-01 | [**curl command**: Understanding the Hidden Powers of curl](https://nordicapis.com/understanding-the-hidden-powers-of-curl) | 🔵 medium | Details advanced curl capabilities like raw TCP manipulation and proxy tunneling crucial for diagnosing cloud API connectivity and ingress paths. |
+    | 2026-06-01 | [abarrak.gitbook.io: Linux SysOps Handbook 🌟](https://abarrak.gitbook.io/linux-sysops-handbook) | 🔵 medium | Serves as a high-density, real-world reference handbook that accelerates on-call incident resolution and performance tuning. |
+    | 2026-06-01 | [igoroseledko.com: Parallel Rsync](https://www.igoroseledko.com/parallel-rsync) | 🔵 medium | Solves single-thread performance bottlenecks during massive data migrations by parallelizing rsync workflows over enterprise networks. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -811,7 +439,40 @@ search:
     | 2026-06-13 | [zx](https://github.com/google/zx) | 🔵 medium | Google's zx empowers platform engineers to write secure and robust system scripts in JavaScript/TypeScript rather than error-prone shell scripting languages. |
     | 2026-06-01 | [abarrak.gitbook.io: Linux SysOps Handbook 🌟](https://abarrak.gitbook.io/linux-sysops-handbook) | 🔵 medium | Serves as an indispensable, high-density reference manual for on-call engineers debugging Linux kernel, memory, and storage subsystems. |
 
-    **Security & Compliance**
+
+## Security & Compliance
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [Tetragon (Cilium)](https://github.com/cilium/tetragon) | 🔴 critical | eBPF-powered security observability at the kernel level represents a paradigm shift for Kubernetes runtime enforcement. |
+    | 2026-06-12 | [hashicorp/vault](https://github.com/hashicorp/vault) | 🔴 critical | It remains the absolute backbone of enterprise Zero Trust architectures and dynamic secrets management across multi-cloud environments. |
+    | 2026-05-17 | [OPA Open Policy Agent 🌟](https://www.openpolicyagent.org) | 🔴 critical | As a CNCF graduated project, OPA defines the industry standard for decoupling policy-as-code from core application logic. |
+    | 2026-06-18 | [Project Calico 🌟](https://www.tigera.io/project-calico) | 🔴 critical | Calico is an industry-standard networking and security engine enabling high-performance eBPF container network interface enforcement. |
+    | 2026-06-11 | [trivy](https://github.com/aquasecurity/trivy) | 🟡 high | Aqua Security's scanner is the dominant tool for container and IaC vulnerability detection within modern CI/CD pipelines. |
+    | 2026-06-13 | [github.com/prowler-cloud/prowler 🌟🌟](https://github.com/prowler-cloud/prowler) | 🟡 high | Prowler is the de facto open-source tool for auditing multi-cloud security posture and compliance against rigorous benchmarks. |
+    | 2026-06-01 | [keycloak.org](https://www.keycloak.org) | 🟡 high | Keycloak stands as the industry-standard open-source identity and access management platform with native cloud integration. |
+    | 2026-05-17 | [checkov.io](https://www.checkov.io) | 🟡 high | It provides dominant static analysis capability for detecting security misconfigurations across infrastructure-as-code files. |
+    | 2026-06-13 | [sops: Simple and flexible tool for managing secrets 🌟](https://github.com/getsops/sops) | 🟡 high | SOPS is the essential, industry-trusted utility for managing file-level secrets within declarative GitOps workflows. |
+    | 2026-06-12 | [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator) | 🟡 high | An official Kubernetes SIG project that simplifies and automates the enforcement of host-level Seccomp and AppArmor profiles. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-12 | [hashicorp/vault](https://github.com/hashicorp/vault) | 🔴 critical | It is the undisputed industry-standard tool for multi-cloud secrets management, dynamic credential brokering, and zero-trust data protection. |
+    | 2026-05-17 | [OPA Open Policy Agent 🌟](https://www.openpolicyagent.org) | 🔴 critical | As a CNCF graduated project, OPA remains the foundational standard for unifying fine-grained, declarative policy-as-code enforcement across microservices. |
+    | 2026-06-11 | [trivy](https://github.com/aquasecurity/trivy) | 🔴 critical | It is the de facto standard for rapid container, package, and Infrastructure-as-Code vulnerability scanning integrated into modern CI/CD pipelines. |
+    | 2025-06-01 | [external-secrets.io 🌟](https://external-secrets.io) | 🟡 high | It is the industry-standard operator that securely bridges external secret management backends directly into native Kubernetes Secrets. |
+    | 2026-06-14 | [Tetragon (Cilium)](https://github.com/cilium/tetragon) | 🟡 high | Provides cutting-edge, eBPF-powered real-time security observability and runtime kernel enforcement to block threats before they reach the application layer. |
+    | 2026-06-18 | [Project Calico 🌟](https://www.tigera.io/project-calico) | 🟡 high | An industry-standard networking and network security engine that leverages eBPF to enforce high-performance microsegmentation policies. |
+    | 2026-06-13 | [github.com/prowler-cloud/prowler 🌟🌟](https://github.com/prowler-cloud/prowler) | 🟡 high | A premier tool for Cloud Security Posture Management (CSPM), enabling automated compliance auditing across multi-cloud environments against global standards. |
+    | 2026-05-17 | [checkov.io](https://www.checkov.io) | 🟡 high | A leading static analysis tool that actively prevents cloud misconfigurations by scanning Infrastructure-as-Code blueprints before deployment. |
+    | 2026-06-12 | [kubernetes-sigs/security-profiles-operator](https://github.com/kubernetes-sigs/security-profiles-operator) | 🟡 high | A Kubernetes SIG-managed project that simplifies the native orchestrating and hardening of Seccomp, AppArmor, and SELinux profiles. |
+    | 2026-06-12 | [kubescape](https://github.com/kubescape/kubescape) | 🟡 high | An active CNCF Sandbox platform that automates multi-framework Kubernetes configuration scanning, risk profiling, and compliance management. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -826,7 +487,40 @@ search:
     | 2026-05-17 | [checkov.io](https://www.checkov.io) | 🟡 high | Checkov is a widely adopted shift-left security tool that prevents vulnerabilities by scanning Infrastructure-as-Code configurations for misconfigurations before deployment. |
     | 2026-06-13 | [sops: Simple and flexible tool for managing secrets 🌟](https://github.com/getsops/sops) | 🟡 high | SOPS is an essential tool for GitOps pipelines, allowing teams to securely encrypt sensitive configuration files before committing them to version control. |
 
-    **Infrastructure as Code**
+
+## Infrastructure as Code
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-02 | [OpenTofu 1.12: the Feature Terraform Never Shipped](https://www.infoq.com/news/2026/05/opentofu-release-terraform) | 🔴 critical | OpenTofu 1.12 solves a major historical limitation of upstream Terraform by introducing dynamic, modular configurations, representing a significant milestone for the open-source fork. |
+    | 2026-06-02 | [The Agentic Infrastructure Era \| Pulumi Releases](https://www.pulumi.com/releases/agentic-infrastructure-era) | 🔴 critical | This release marks a fundamental paradigm shift in cloud engineering toward autonomous, agent-driven infrastructure provisioning and self-healing environments. |
+    | 2026-06-02 | [New in Terraform 1.15: Dynamic sources, variable deprecation, and more](https://www.hashicorp.com/en/blog/new-in-terraform-115-dynamic-sources-variable-deprecation-and-more) | 🟡 high | The introduction of native dynamic module sources and version parsing in Terraform 1.15 directly improves how enterprises manage and inject variable configurations into upstream dependencies. |
+    | 2026-05-29 | [github.com/terraform-aws-modules/terraform-aws-eks: AWS EKS Terraform module](https://github.com/terraform-aws-modules/terraform-aws-eks) | 🟡 high | As the industry-standard module for deploying AWS EKS, this resource remains a critical foundational component for cloud-native Kubernetes infrastructure. |
+    | 2026-06-02 | [Neo, Now in the Terminal \| Pulumi Blog](https://www.pulumi.com/blog/pulumi-neo-cli) | 🟡 high | Bringing the Neo AI assistant directly into the terminal interface introduces a highly novel, agentic UX for local infrastructure generation and debugging. |
+    | 2026-06-09 | [github.com/microsoft/terraform-provider-azuredevops/releases/tag/v1.0.0](https://github.com/microsoft/terraform-provider-azuredevops/releases/tag/v1.0.0) | 🟡 high | Reaching GA v1.0.0 establishes critical production-readiness for enterprises looking to fully govern their Azure DevOps platforms through declarative IaC. |
+    | 2026-06-03 | [Infracost 🌟](https://github.com/infracost/infracost) | 🟡 high | This tool enables proactive FinOps governance by parsing HCL files to output precise cloud cost projections before infrastructure changes are applied. |
+    | 2026-03-05 | [Kubestack Gitops Framework](https://github.com/kbst/terraform-kubestack) | 🟡 high | A specialized GitOps framework that natively leverages Terraform's configuration inheritance to streamline multi-cluster Kubernetes platform deployments. |
+    | 2026-05-27 | [mineiros-io/terramate](https://github.com/terramate-io/terramate) | 🟡 high | Terramate optimizes modern platform engineering operations by solving code duplication and change-detection bottlenecks within large-scale multi-directory IaC monorepos. |
+    | 2026-06-10 | [AWX Operator](https://github.com/ansible/awx-operator) | 🔵 medium | The AWX Operator brings legacy automation frameworks into the cloud-native era by orchestrating the AWX lifecycle using native Kubernetes Custom Resource Definitions. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-02 | [OpenTofu 1.12: the Feature Terraform Never Shipped](https://www.infoq.com/news/2026/05/opentofu-release-terraform) | 🔴 critical | Successfully solves a long-standing limitation in modular configuration, marking a significant milestone for the OpenTofu open-source fork. |
+    | 2026-06-02 | [The Agentic Infrastructure Era \| Pulumi Releases](https://www.pulumi.com/releases/agentic-infrastructure-era) | 🔴 critical | Introduces a major paradigm shift toward autonomous, agent-driven cloud provisioning and self-healing infrastructure systems. |
+    | 2026-06-02 | [New in Terraform 1.15: Dynamic sources, variable deprecation, and more](https://www.hashicorp.com/en/blog/new-in-terraform-115-dynamic-sources-variable-deprecation-and-more) | 🔴 critical | Introduces native dynamic module sources and versioning, fundamentally changing how practitioners configure upstream dependencies at initialization. |
+    | 2026-05-29 | [github.com/terraform-aws-modules/terraform-aws-eks: AWS EKS Terraform module](https://github.com/terraform-aws-modules/terraform-aws-eks) | 🟡 high | Serves as the battle-tested, community-standard blueprint for orchestrating complex enterprise Amazon EKS cluster deployments. |
+    | 2025-12-10 | [terraform-cdk 🌟](https://github.com/hashicorp/terraform-cdk) | 🟡 high | Allows software engineering teams to use imperative languages like TypeScript and Python to build declarative cloud native infrastructure. |
+    | 2025-06-01 | [terragrunt.gruntwork.io](https://terragrunt.com) | 🟡 high | Remains the industry-standard orchestrator for keeping large-scale IaC configurations DRY and managing complex cross-module dependencies. |
+    | 2026-05-27 | [mineiros-io/terramate](https://github.com/terramate-io/terramate) | 🟡 high | Optimizes large-scale multi-directory monorepos with advanced selective change detection and automated code generation. |
+    | 2026-06-10 | [AWX Operator](https://github.com/ansible/awx-operator) | 🟡 high | Enables Kubernetes-native lifecycle management, scaling, and CRD-driven automation of Ansible AWX deployments. |
+    | 2026-06-03 | [Infracost 🌟](https://github.com/infracost/infracost) | 🟡 high | Integrates directly into CI/CD pipelines to provide real-time FinOps cloud cost projections before resources are provisioned. |
+    | 2026-03-05 | [Kubestack Gitops Framework](https://github.com/kbst/terraform-kubestack) | 🟡 high | Bridges the gap between declarative cloud infrastructure and GitOps application delivery workflows on Kubernetes. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -841,7 +535,40 @@ search:
     | 2026-05-27 | [mineiros-io/terramate](https://github.com/terramate-io/terramate) | 🔵 medium | Implements powerful orchestration and change detection mechanisms designed to scale multi-directory Terraform and OpenTofu monorepos. |
     | 2026-05-21 | [terraform-review-agent](https://github.com/infiniumtek/terraform-review-agent) | 🔵 medium | Pioneers the use of AI agents for cognitive review of IaC configurations, moving beyond simple static linting. |
 
-    **CI/CD & GitOps**
+
+## CI/CD & GitOps
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Argo CD](https://argoproj.github.io/argo-cd) | 🔴 critical | As the industry standard for GitOps-based continuous delivery, Argo CD is vital for synchronizing live Kubernetes cluster states with declarative Git configurations. |
+    | 2026-06-13 | [github: Flux Version 2](https://github.com/fluxcd/flux2) | 🔴 critical | Flux v2 is a foundational CNCF graduated project that implements a highly parallelized, modular GitOps controller architecture for enterprise-grade reconciliation. |
+    | 2026-06-14 | [dagger/dagger: Dagger is a portable devkit for CICD](https://github.com/dagger/dagger) | 🔴 critical | Dagger represents a major paradigm shift in CI/CD by replacing brittle YAML pipelines with portable, code-driven workflows executed on BuildKit. |
+    | 2026-06-14 | [github: Tekton Pipelines](https://github.com/tektoncd/pipeline) | 🟡 high | Tekton Pipelines provides the definitive Kubernetes-native CI engine using custom resource definitions to run modular, containerized build steps. |
+    | 2026-06-08 | [github.com/flux-iac/tofu-controller](https://github.com/flux-iac/tofu-controller) | 🟡 high | The tofu-controller natively brings GitOps principles to OpenTofu and Terraform, standardizing infrastructure-as-code execution within Kubernetes control planes. |
+    | 2026-06-14 | [Helm](https://nubenetes.com/helm) | 🟡 high | Helm remains the indispensable package manager for Kubernetes, defining how cloud-native applications are structured, versioned, and shared across environments. |
+    | 2026-06-14 | [Keptn](https://nubenetes.com/keptn) | 🟡 high | Keptn bridges continuous delivery and operations by orchestrating SLO-based quality gates and automated canary promotions using cloud-native control planes. |
+    | 2026-06-14 | [feat(ui): Add AppSet to Application Resource Tree in Argo CD](https://github.com/argoproj/argo-cd/pull/26601) | 🟡 high | Integrating ApplicationSets directly into the Argo CD UI greatly simplifies the observability and visualization of complex, multi-tenant GitOps topologies. |
+    | 2026-06-08 | [kubernetes-plugin: Kubernetes plugin for Jenkins 🌟](https://github.com/jenkinsci/kubernetes-plugin) | 🟡 high | This plugin is critical for hybrid enterprises modernizing legacy workloads, allowing Jenkins to dynamically scale isolated executor pods directly on Kubernetes. |
+    | 2026-06-14 | [github.com/glasskube/glasskube](https://github.com/glasskube/glasskube) | 🟡 high | Glasskube introduces a next-generation package manager for Kubernetes, significantly improving package discovery, automated updates, and dependency management. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Argo CD](https://argoproj.github.io/argo-cd) | 🔴 critical | Argo CD remains the absolute industry standard for pull-based GitOps reconciliation and continuous delivery on Kubernetes. |
+    | 2026-06-13 | [github: Flux Version 2](https://github.com/fluxcd/flux2) | 🔴 critical | Flux v2 is a foundational, graduated CNCF GitOps engine engineered specifically for highly decoupled, parallel cluster synchronization. |
+    | 2026-06-14 | [dagger/dagger: Dagger is a portable devkit for CICD](https://github.com/dagger/dagger) | 🔴 critical | Dagger represents a major paradigm shift in CI/CD, replacing fragile YAML/Bash scripts with portable pipelines written in standard languages and executed via BuildKit. |
+    | 2026-06-14 | [Helm](https://nubenetes.com/helm) | 🟡 high | Helm is the undisputed standard package manager for Kubernetes, serving as a critical packaging cornerstone for modern GitOps engines. |
+    | 2026-06-14 | [github: Tekton Pipelines](https://github.com/tektoncd/pipeline) | 🟡 high | Tekton provides the standard cloud-native CI/CD framework using Kubernetes-native Custom Resource Definitions for structured, scalable task execution. |
+    | 2026-06-08 | [github.com/flux-iac/tofu-controller](https://github.com/flux-iac/tofu-controller) | 🟡 high | The OpenTofu controller natively extends GitOps synchronization paradigms beyond Kubernetes manifests to cloud infrastructure resources. |
+    | 2025-06-01 | [Jenkins Configuration as Code](https://www.jenkins.io/projects/jcasc) | 🟡 high | Jenkins Configuration as Code (JCasC) provides a critical production-ready path to manage legacy CI infrastructure under modern GitOps and declarative paradigms. |
+    | 2026-06-13 | [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) | 🟡 high | Prow is the leading cloud-native CI/CD platform engineered to handle massive-scale, decentralized, event-driven repository governance. |
+    | 2026-06-14 | [github.com/glasskube/glasskube](https://github.com/glasskube/glasskube) | 🟡 high | Glasskube represents a major technical novelty as a next-generation Kubernetes package manager designed to simplify dependency management and upgrades over traditional Helm. |
+    | 2026-06-14 | [feat(ui): Add AppSet to Application Resource Tree in Argo CD](https://github.com/argoproj/argo-cd/pull/26601) | 🔵 medium | This Argo CD enhancement directly improves enterprise observability for multi-tenant topologies by natively mapping ApplicationSets in the dashboard UI. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -856,7 +583,40 @@ search:
     | 2026-06-08 | [kubernetes-plugin: Kubernetes plugin for Jenkins 🌟](https://github.com/jenkinsci/kubernetes-plugin) | 🟡 high | Allows Jenkins to dynamically scale build execution capacities by provisioning isolated worker pods on-demand inside Kubernetes. |
     | 2026-06-14 | [github.com/glasskube/glasskube](https://github.com/glasskube/glasskube) | 🟡 high | A next-generation Kubernetes package manager written in Go that simplifies operator deployment and automated lifecycle updates. |
 
-    **Observability, SRE & Testing**
+
+## Observability, SRE & Testing
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-12 | [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) | 🔴 critical | Acts as the industry-standard, vendor-agnostic pipeline for receiving, processing, and routing metrics, logs, and traces across diverse cloud-native environments. |
+    | 2026-06-13 | [github.com/prometheus/prometheus](https://github.com/prometheus/prometheus) | 🔴 critical | Serves as the foundational, de-facto standard metrics database and query engine powering the entire cloud-native observability ecosystem. |
+    | 2026-05-17 | [github.com/prometheus-operator](https://github.com/prometheus-operator) | 🔴 critical | Pioneered the operator pattern to fully automate the deployment, configuration, and scaling of Prometheus instances in Kubernetes. |
+    | 2026-06-14 | [kube-state-metrics 🌟](https://github.com/kubernetes/kube-state-metrics) | 🔴 critical | Essential cluster service that translates internal Kubernetes API resources into Prometheus metrics for accurate, real-time infrastructure state analysis. |
+    | 2026-06-13 | [Grafana Tempo](https://github.com/grafana/tempo) | 🟡 high | Redefines distributed tracing scalability by using cost-effective object storage to manage massive volumes of enterprise trace data without massive storage bills. |
+    | 2026-06-13 | [github.com/open-telemetry/opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-operator) | 🟡 high | Simplifies enterprise telemetry adoption by automating zero-code application instrumentation and collector management inside Kubernetes. |
+    | 2026-06-12 | [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) | 🟡 high | Serves as the gold-standard reference monitoring stack, combining critical observability components for immediate out-of-the-box cluster visibility. |
+    | 2026-06-12 | [Chaos Mesh](https://github.com/chaos-mesh/chaos-mesh) | 🟡 high | Provides a robust, CNCF-incubating platform to seamlessly orchestrate chaos engineering experiments directly inside cloud-native topologies. |
+    | 2026-06-14 | [github.com/grafana/mimir](https://github.com/grafana/mimir) | 🟡 high | Delivers production-ready, horizontally-scalable, and multi-tenant long-term metrics storage designed for high-volume enterprise workloads. |
+    | 2026-06-14 | [grafana.com: How to manage high cardinality metrics in Prometheus and Kubernetes](https://grafana.com/blog/how-to-manage-high-cardinality-metrics-in-prometheus-and-kubernetes) | 🟡 high | Addresses high cardinality, the most prominent operational and financial pain point in cloud-native monitoring, with proven optimization techniques. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-13 | [github.com/prometheus/prometheus](https://github.com/prometheus/prometheus) | 🔴 critical | Prometheus remains the industry-standard, benchmark telemetry engine for modern cloud-native metrics collection and real-time alerting. |
+    | 2026-06-12 | [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) | 🔴 critical | The OpenTelemetry Collector serves as the essential, vendor-agnostic pipeline engine for modern enterprise telemetry collection and routing. |
+    | 2026-05-17 | [github.com/prometheus-operator](https://github.com/prometheus-operator) | 🔴 critical | The Prometheus Operator is the foundational controller that automates the deployment, scaling, and configuration of monitoring instances in Kubernetes. |
+    | 2026-06-12 | [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) | 🟡 high | Kube-prometheus provides the definitive, production-ready reference architecture for monitoring Kubernetes control planes and node workloads. |
+    | 2026-06-13 | [Grafana Tempo](https://github.com/grafana/tempo) | 🟡 high | Grafana Tempo offers highly scalable, cost-effective distributed tracing utilizing only object storage to lower enterprise observability costs. |
+    | 2026-06-13 | [github.com/open-telemetry/opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-operator) | 🟡 high | The OpenTelemetry Operator simplifies cloud-native observability by automating collector deployments and application auto-instrumentation on Kubernetes. |
+    | 2026-06-12 | [Chaos Mesh](https://github.com/chaos-mesh/chaos-mesh) | 🟡 high | Chaos Mesh provides a powerful CNCF-incubating platform to systematically inject faults and validate system resilience in Kubernetes. |
+    | 2026-06-09 | [Litmus Chaos is a toolset to do chaos engineering in a kubernetes native way. Litmus provides chaos CRDs for Cloud-Native developers and SREs to inject, orchestrate and monitor chaos to find weaknesses in Kubernetes deployments](https://github.com/litmuschaos/litmus) | 🟡 high | Litmus Chaos enables SREs to orchestrate Kubernetes-native chaos experiments directly through declarative, CRD-driven pipelines. |
+    | 2026-06-14 | [Netdata](https://github.com/netdata/netdata) | 🟡 high | Netdata delivers ultra-high-performance, zero-configuration system monitoring with massive community adoption for real-time physical and virtual host diagnostics. |
+    | 2026-06-08 | [Sloth 🌟](https://github.com/slok/sloth) | 🔵 medium | Sloth automates SRE practices by translating simple declarative YAML definitions into complex, production-grade PromQL multi-burn-rate alerting rules. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -871,7 +631,40 @@ search:
     | 2025-06-01 | [Locust](https://locust.io) | 🟡 high | Shifts performance testing left by allowing SREs to write highly scalable, developer-friendly load-testing scenarios in pure Python. |
     | 2026-06-14 | [Netdata](https://github.com/netdata/netdata) | 🟡 high | Provides zero-configuration, per-second real-time system monitoring with an immense community footprint of over 79k stars. |
 
-    **DevOps & Culture**
+
+## DevOps & Culture
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-13 | [github.com/backstage/backstage](https://github.com/backstage/backstage) | 🔴 critical | Backstage is the industry-standard CNCF framework for building internal developer portals, drastically reducing cognitive load for platform engineering teams. |
+    | 2026-06-12 | [Azure DevOps MCP Server](https://github.com/microsoft/azure-devops-mcp) | 🟡 high | It bridges AI agents with enterprise CI/CD environments, enabling agentic orchestration and automated management of Azure DevOps workflows. |
+    | 2026-06-10 | [Devtron](https://github.com/devtron-labs/devtron) | 🟡 high | Devtron simplifies Kubernetes AppOps by consolidating GitOps, CI/CD, and multi-cluster observability into a unified self-service platform. |
+    | 2026-06-14 | [blog.postman.com: What Is PlatformOps?](https://blog.postman.com/what-is-platformops) | 🟡 high | This article defines the rise of PlatformOps as the operational engine behind Platform Engineering, marking a crucial evolution in cloud-native organizational structures. |
+    | 2026-05-29 | [action-tmate: Debug GitHub Actions via SSH](https://github.com/mxschmitt/action-tmate) | 🟡 high | An invaluable interactive debugging utility that significantly accelerates pipeline troubleshooting by opening secure SSH connections into live GitHub Actions runs. |
+    | 2026-06-14 | [IaC Infrastructure as Code](https://nubenetes.com/iac) | 🟡 high | An essential cloud-native architectural guide outlining the modern philosophies, lifecycles, and state management of Infrastructure as Code. |
+    | 2026-06-14 | [NoOps](https://nubenetes.com/noops) | 🟡 high | Provides a strategic roadmap for the transition to NoOps, highlighting how teams can outsource operational overhead using automated serverless paradigms. |
+    | 2026-06-02 | [Introducing Cursor in Jira - Inside Atlassian](https://www.atlassian.com/blog/company-news/cursor-in-jira) | 🟡 high | Integrates cutting-edge AI development tools with standard agile tracking, bridging the gap between automated code generation and project management workflows. |
+    | 2026-06-14 | [DevOps Tools](https://nubenetes.com/devops-tools) | 🔵 medium | Offers a comprehensive mapping of modern DevOps tooling to build and scale stable, automated production delivery pipelines. |
+    | 2026-06-14 | [blog.vmware.com: DevOps: Culture – Collaboration, Empowerment, Autonomy 🌟](https://blogs.vmware.com/cloud-foundation) | 🔵 medium | Highlights the critical organizational and cultural transformations, such as psychological safety and autonomy, required to sustain successful DevOps practices. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-13 | [github.com/backstage/backstage](https://github.com/backstage/backstage) | 🔴 critical | It is the de facto industry-standard framework for building customizable internal developer portals, centralizing platform engineering workflows. |
+    | 2026-06-12 | [Azure DevOps MCP Server](https://github.com/microsoft/azure-devops-mcp) | 🟡 high | Bridges AI-native agents and Azure DevOps, enabling automated task and workflow management directly via LLMs. |
+    | 2026-06-10 | [Devtron](https://github.com/devtron-labs/devtron) | 🟡 high | Simplifies complex Kubernetes operations by unifying CI/CD, GitOps, and multi-cluster observability into a cohesive self-service portal. |
+    | 2026-06-14 | [IaC Infrastructure as Code](https://nubenetes.com/iac) | 🟡 high | Provides a critical cloud-native reference architecture for managing infrastructure and cluster state declaratively. |
+    | 2026-06-02 | [Introducing Cursor in Jira - Inside Atlassian](https://www.atlassian.com/blog/company-news/cursor-in-jira) | 🟡 high | Represents a paradigm shift in project management by integrating ticket-tracking directly with autonomous AI coding agents. |
+    | 2026-01-04 | [github.com/KusionStack/kusion](https://github.com/KusionStack/kusion) | 🟡 high | Enables intent-driven declarative configuration to streamline and unify application delivery across multi-cloud platforms. |
+    | 2026-05-29 | [action-tmate: Debug GitHub Actions via SSH](https://github.com/mxschmitt/action-tmate) | 🔵 medium | Drastically improves developer troubleshooting loops by providing secure interactive SSH access to active CI/CD runners. |
+    | 2026-06-14 | [blog.postman.com: What Is PlatformOps?](https://blog.postman.com/what-is-platformops) | 🟡 high | Defines the strategic transition from traditional DevOps to PlatformOps, treating developer tooling and infrastructure as internal products. |
+    | 2026-06-14 | [NoOps](https://nubenetes.com/noops) | 🔵 medium | Synthesizes the operational path toward abstracting infrastructure layers entirely through automation, serverless models, and self-healing systems. |
+    | 2026-06-14 | [DevOps Tools](https://nubenetes.com/devops-tools) | 🔵 medium | Curates the essential modern tooling pipeline required to orchestrate continuous integration, container scheduling, and real-time telemetry. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -886,7 +679,40 @@ search:
     | 2026-06-14 | [blog.vmware.com: DevOps: Culture – Collaboration, Empowerment, Autonomy 🌟](https://blogs.vmware.com/cloud-foundation) | 🔵 medium | Addresses the essential cultural requirements of DevOps including decentralized decisions, psychological safety, and team empowerment. |
     | 2026-06-14 | [DevOps Tools](https://nubenetes.com/devops-tools) | 🔵 medium | A foundational mapping of essential continuous integration, telemetry, and delivery tools needed to construct stable release pipelines. |
 
-    **Platform Engineering & DevEx**
+
+## Platform Engineering & DevEx
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Backstage Developer Portal:](https://backstage.io) | 🔴 critical | As a CNCF-graduated project, it is the de facto open-source framework for building internal developer portals to centralize platform tooling. |
+    | 2026-06-11 | [Azure/Draft 🌟](https://github.com/Azure/draft) | 🔴 critical | Significantly reduces Kubernetes onboarding friction by automatically generating containerization assets and deployment manifests directly from source code. |
+    | 2026-06-01 | [Kong API Manager](https://konghq.com/products/kong-gateway) | 🟡 high | A highly customizable and widely adopted lightweight API gateway that serves as a cornerstone for cloud-native microservices routing. |
+    | 2026-06-12 | [apisix](https://github.com/apache/apisix) | 🟡 high | A high-performance Apache-backed cloud-native API gateway that offers dynamic routing and active health checking for large-scale platforms. |
+    | 2026-06-01 | [docs.traefik.io](https://doc.traefik.io/traefik) | 🟡 high | An industry-standard cloud-native edge router and ingress controller that simplifies dynamic configuration and routing in Kubernetes. |
+    | 2026-06-01 | [KrakenD: The fastest API gateway comes with true linear scalability 🌟](https://www.krakend.io) | 🟡 high | Delivers an ultra-high performance, stateless API gateway engine designed to scale linearly without the overhead of central databases. |
+    | 2026-06-01 | [Material for MkDocs](https://squidfunk.github.io/mkdocs-material) | 🔵 medium | Serves as the industry-standard UI layout for engineering documentation, dramatically improving the developer experience through clean, navigable guides. |
+    | 2026-06-01 | [Tyk API Manager](https://tyk.io) | 🔵 medium | A powerful Go-based gateway that offers exceptional clustering and dynamic rate limiting to robustly scale cloud-native platforms. |
+    | 2026-06-01 | [Red Hat 3scale API Management](https://www.redhat.com/en/technologies/jboss-middleware/3scale) | 🔵 medium | Provides an operator-driven, containerized API management solution optimized for enterprise Red Hat OpenShift environments. |
+    | 2026-06-01 | [Spring Cloud Gateway](https://spring.io/projects/spring-cloud-gateway) | 🔵 medium | An essential reactive routing gateway that bridges the gap between enterprise Java developers and cloud-native microservice architectures. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [Backstage Developer Portal:](https://backstage.io) | 🔴 critical | As the premier CNCF project for building internal developer portals, Backstage is the industry-standard foundation for enterprise Platform Engineering and DevEx. |
+    | 2026-06-11 | [Azure/Draft 🌟](https://github.com/Azure/draft) | 🟡 high | Streamlines cloud-native developer experience by scanning application source code to automatically generate Dockerfiles and Kubernetes manifests. |
+    | 2026-06-01 | [Kong API Manager](https://konghq.com/products/kong-gateway) | 🔴 critical | Stands as the world's most popular lightweight API gateway, serving as a critical traffic routing and policy enforcement layer in microservice platforms. |
+    | 2026-06-12 | [apisix](https://github.com/apache/apisix) | 🟡 high | Provides a high-performance, fully dynamic cloud-native API gateway built on Nginx that is ideal for handling dynamic routing and telemetry integration. |
+    | 2026-06-01 | [Material for MkDocs](https://squidfunk.github.io/mkdocs-material) | 🟡 high | Acts as the de facto industry standard UI for engineering documentation, enabling modern docs-as-code workflows that dramatically elevate DevEx. |
+    | 2026-06-01 | [docs.traefik.io](https://doc.traefik.io/traefik) | 🟡 high | Traefik is a foundational cloud-native ingress proxy designed to dynamically configure and route traffic within containerized environments. |
+    | 2026-06-01 | [Google Apigee API Manager](https://cloud.google.com/apigee) | 🟡 high | Provides enterprise-grade API management and security globally, serving as a robust centralized control plane for large-scale hybrid cloud platforms. |
+    | 2026-06-01 | [Red Hat 3scale API Management](https://www.redhat.com/en/technologies/jboss-middleware/3scale) | 🔵 medium | Delivers a Kubernetes-native, operator-driven API management framework optimized for secure microservices delivery on enterprise platforms like Red Hat OpenShift. |
+    | 2026-06-01 | [Tyk API Manager](https://tyk.io) | 🔵 medium | Offers an ultra-lightweight and highly performant Go-based API gateway with excellent multi-datacenter and dynamic clustering capabilities. |
+    | 2026-06-01 | [readme.so](https://readme.so) | 🔵 medium | Directly enhances early-stage developer experience by providing an intuitive interactive builder to standardize and accelerate repository documentation. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -901,7 +727,40 @@ search:
     | 2026-06-01 | [Red Hat 3scale API Management](https://www.redhat.com/en/technologies/jboss-middleware/3scale) | 🔵 medium | Red Hat 3scale provides an operator-driven API management framework optimized for scaling microservices securely within OpenShift and Kubernetes environments. |
     | 2026-06-01 | [MkDocs](https://www.mkdocs.org) | 🔵 medium | MkDocs is an extensible, Python-based static site generator that streamlines the developer experience by compiling Markdown into production-ready documentation. |
 
-    **FinOps & Cloud Cost**
+
+## FinOps & Cloud Cost
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [FinOps Foundation: FinOps.org](https://www.finops.org) | 🔴 critical | Serves as the foundational, Linux Foundation-backed industry standard defining FinOps practices, frameworks, and open billing data specifications like FOCUS. |
+    | 2026-05-17 | [cast.ai: Keep your AWS Kubernetes costs in check with intelligent allocation' (EKS)](https://cast.ai/blog/keep-your-aws-kubernetes-costs-in-check-with-intelligent-allocation) | 🟡 high | Demonstrates automated container resource provisioning and dynamic node allocation to prevent cost-heavy over-provisioning in EKS environments. |
+    | 2026-06-18 | [cncf.io: FinOps for Kubernetes: Insufficient – or nonexistent – Kubernetes' cost monitoring is causing overspend](https://www.cncf.io/blog/2021/06/29/finops-for-kubernetes-insufficient-or-nonexistent-kubernetes-cost-monitoring-is-causing-overspend) | 🟡 high | Provides a vital CNCF community perspective highlighting how inadequate Kubernetes cost visibility directly leads to runaway cloud spend. |
+    | 2026-04-09 | [Cloudburn: An Open-Source Policy Engine for AWS Spending](https://github.com/towardsthecloud/cloudburn) | 🟡 high | Introduces an open-source, declarative policy engine that allows platform teams to programmatically audit and restrict idle AWS infrastructure. |
+    | 2026-05-17 | [engineering.razorpay.com: The Culture of Cost Optimization — Reducing Kubernetes' cost by $300,000](https://engineering.razorpay.com/the-culture-of-cost-optimization-reducing-kubernetes-cost-by-300-000-32611cdd19d9) | 🟡 high | Shares concrete, production-scale engineering strategies that successfully shaved $300,000 off a high-volume Kubernetes cluster's operational costs. |
+    | 2026-05-17 | [Visualize and gain insights into your AWS cost and usage with Cloud Intelligence Dashboards and CUDOS using Amazon QuickSight](https://aws.amazon.com/blogs/mt/visualize-and-gain-insights-into-your-aws-cost-and-usage-with-cloud-intelligence-dashboards-using-amazon-quicksight) | 🟡 high | Delivers an enterprise-grade blueprint for building robust, real-time billing visualizations and anomaly detection using AWS CUDOS and QuickSight. |
+    | 2026-05-17 | [medium.com/develeap: Cutting down Kubernetes Costs: Cast.ai vs. Karpenter](https://medium.com/develeap/cutting-down-kubernetes-costs-cast-ai-vs-karpenter-20f6788b4c67) | 🔵 medium | Presents a crucial technical evaluation between two leading Kubernetes autoscaling and cost-optimization technologies, Karpenter and Cast.ai. |
+    | 2026-05-17 | [medium.com/@danielepolencic: In Kubernetes, are there hidden costs to' running many cluster nodes?](https://medium.com/@danielepolencic/reserved-cpu-and-memory-in-kubernetes-nodes-65aee1946afd) | 🔵 medium | Unpacks the critical system-level CPU and memory reservation overheads that act as hidden cost drivers when scaling up Kubernetes nodes. |
+    | 2026-06-18 | [learnk8s/xlskubectl](https://github.com/learnk8s/xlskubectl) | 🔵 medium | Bridges the gap between engineering CLI outputs and financial analysis by dynamically exporting Kubernetes resource metrics into interactive spreadsheets. |
+    | 2026-05-18 | [Announcing General Availability of AWS Cost Anomaly Detection](https://aws.amazon.com/blogs/aws-cloud-financial-management/announcing-general-availability-of-aws-cost-anomaly-detection) | 🟡 high | Offers native, machine-learning-driven spend anomaly detection to proactively flag and prevent runaway cloud billing events before they escalate. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [FinOps Foundation: FinOps.org](https://www.finops.org) | 🔴 critical | Serves as the foundational standard-setting body codifying FinOps practices, frameworks, and open specifications like FOCUS for cloud-native architectures. |
+    | 2026-06-18 | [cncf.io: FinOps for Kubernetes: Insufficient – or nonexistent – Kubernetes' cost monitoring is causing overspend](https://www.cncf.io/blog/2021/06/29/finops-for-kubernetes-insufficient-or-nonexistent-kubernetes-cost-monitoring-is-causing-overspend) | 🔴 critical | Provides CNCF-backed guidance on why visibility and cost monitoring are crucial to stopping runaway costs in complex Kubernetes deployments. |
+    | 2026-05-17 | [engineering.razorpay.com: The Culture of Cost Optimization — Reducing Kubernetes' cost by $300,000](https://engineering.razorpay.com/the-culture-of-cost-optimization-reducing-kubernetes-cost-by-300-000-32611cdd19d9) | 🟡 high | Offers a highly valuable real-world enterprise blueprint on how cultural and technical optimizations slashed Kubernetes spending by $300,000. |
+    | 2026-05-17 | [medium.com/develeap: Cutting down Kubernetes Costs: Cast.ai vs. Karpenter](https://medium.com/develeap/cutting-down-kubernetes-costs-cast-ai-vs-karpenter-20f6788b4c67) | 🟡 high | Compares the leading automated cloud-native node provisioning technologies, Cast.ai and Karpenter, which represent the state-of-the-art in container cost optimization. |
+    | 2026-05-17 | [cast.ai: Keep your AWS Kubernetes costs in check with intelligent allocation' (EKS)](https://cast.ai/blog/keep-your-aws-kubernetes-costs-in-check-with-intelligent-allocation) | 🟡 high | Demonstrates how automated container provisioning and dynamic node scaling can drastically curb resource over-provisioning on managed Kubernetes. |
+    | 2026-04-09 | [Cloudburn: An Open-Source Policy Engine for AWS Spending](https://github.com/towardsthecloud/cloudburn) | 🟡 high | Introduces a novel open-source policy engine that applies declarative, GitOps-friendly auditing rules specifically to cloud infrastructure spending. |
+    | 2026-05-17 | [medium.com/@danielepolencic: In Kubernetes, are there hidden costs to' running many cluster nodes?](https://medium.com/@danielepolencic/reserved-cpu-and-memory-in-kubernetes-nodes-65aee1946afd) | 🟡 high | Delivers an essential technical deep-dive into the hidden overhead costs of node-level CPU and memory reservation in Kubernetes clusters. |
+    | 2026-05-18 | [thenewstack.io: 7 Tips for Cutting Down Your AWS Kubernetes Bill](https://thenewstack.io/kubernetes/7-tips-for-cutting-down-your-aws-kubernetes-bill) | 🟡 high | Compiles highly actionable, industry-standard strategies including Spot instances and auto-scalers like Karpenter to optimize EKS bills. |
+    | 2026-05-17 | [medium.com/compass-true-north: Halving Kubernetes Compute Costs With Vertical' Pod Autoscaler](https://medium.com/compass-true-north/halving-kubernetes-compute-costs-with-vertical-pod-autoscaler-df658c043301) | 🟡 high | Illustrates how utilizing the Vertical Pod Autoscaler (VPA) can automate container rightsizing and halve compute costs in production. |
+    | 2026-06-18 | [learnk8s/xlskubectl](https://github.com/learnk8s/xlskubectl) | 🔵 medium | Provides a novel technical tool that bridges the gap between engineering CLI outputs and finance spreadsheets for easy cost forecasting. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -916,7 +775,40 @@ search:
     | 2026-05-17 | [engineering.razorpay.com: The Culture of Cost Optimization — Reducing Kubernetes' cost by $300,000](https://engineering.razorpay.com/the-culture-of-cost-optimization-reducing-kubernetes-cost-by-300-000-32611cdd19d9) | 🟡 high | A massive production-proven case study demonstrating real-world architecture optimizations that successfully slashed Kubernetes costs by $300,000. |
     | 2026-05-17 | [medium.com/compass-true-north: Halving Kubernetes Compute Costs With Vertical' Pod Autoscaler](https://medium.com/compass-true-north/halving-kubernetes-compute-costs-with-vertical-pod-autoscaler-df658c043301) | 🟡 high | Demonstrates a major cloud-native shift, proving how Vertical Pod Autoscaling can be harnessed to slash compute costs in half. |
 
-    **Certification & Training**
+
+## Certification & Training
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [The Linux Foundation Training](https://training.linuxfoundation.org/resources) | 🔴 critical | The definitive training home of the Linux Foundation, serving as the official curriculum and exam administrator for CKA, CKAD, and CKS. |
+    | 2026-06-01 | [kubernetes.io 🌟](https://kubernetes.io/docs/reference/kubectl/quick-reference) | 🔴 critical | The ultimate kubectl quick reference and the only canonical documentation permitted for live lookup during Kubernetes certification exams. |
+    | 2026-06-01 | [Whizlabs](https://www.whizlabs.com) | 🟡 high | Provides highly sought-after practice simulations and sandbox environments explicitly mapped to cloud-native certifications like CKA and CKS. |
+    | 2026-06-01 | [kube.academy](https://kube.academy) | 🟡 high | An outstanding, structured platform sponsored by VMware Tanzu that delivers highly technical, modular tracks for Kubernetes cluster operators. |
+    | 2026-06-01 | [edx.org](https://www.edx.org) | 🟡 high | Hosts the official Linux Foundation training catalog, delivering foundational to advanced university-grade cloud-native education. |
+    | 2026-06-08 | [stefanprodan/podinfo](https://github.com/stefanprodan/podinfo) | 🟡 high | The standard reference application used globally to teach and demonstrate Kubernetes orchestration, health checking, and progressive delivery. |
+    | 2026-06-18 | [techiescamp/devops-projects:Real-World DevOps Projects For Learning](https://github.com/techiescamp/devops-projects) | 🟡 high | A comprehensive hands-on library of real-world DevOps projects providing direct, template-based learning for CI/CD and infrastructure-as-code. |
+    | 2026-06-01 | [techstudyslack.com](https://techstudyslack.com) | 🔵 medium | An active peer community offering specialized debugging support and study guides tailored for passing Kubernetes certifications. |
+    | 2026-06-18 | [github.com/devoriales/kubectl-cheatsheet](https://github.com/devoriales/cheatsheets) | 🔵 medium | An opinionated kubectl reference sheet focusing on node-level troubleshooting and network debugging, crucial for certification practice. |
+    | 2026-06-03 | [github.com/learning-cloud-native-go/myapp: Learning Cloud Native Go -' myapp 🌟](https://github.com/learning-cloud-native-go/myapp) | 🔵 medium | An educational Go application specifically built to demonstrate cloud-native microservice essentials like telemetry and probe implementation. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [The Linux Foundation Training](https://training.linuxfoundation.org/resources) | 🔴 critical | As the official home for the CKA, CKAD, and CKS curricula, this is the single most critical training source for cloud-native professionals. |
+    | 2026-06-01 | [kubernetes.io 🌟](https://kubernetes.io/docs/reference/kubectl/quick-reference) | 🟡 high | The canonical kubectl quick reference is an indispensable daily tool and exam aid for candidates preparing for hands-on CNCF certifications. |
+    | 2026-06-01 | [kube.academy](https://kube.academy) | 🟡 high | This VMware Tanzu-sponsored platform offers high-quality, free modular tracks specifically designed to teach advanced Kubernetes administration concepts. |
+    | 2026-06-01 | [Whizlabs](https://www.whizlabs.com) | 🟡 high | Provides highly realistic exam simulators and sandbox environments specifically designed for preparing candidates to pass the CKA, CKAD, and CKS. |
+    | 2026-06-01 | [edx.org](https://www.edx.org) | 🟡 high | Hosts the official introductory curricula from the Linux Foundation, acting as a primary starting point for university-grade cloud-native certificates. |
+    | 2025-04-27 | [AdminTurnedDevOps/DevOps-The-Hard-Way-AWS](https://github.com/AdminTurnedDevOps/DevOps-The-Hard-Way-AWS) | 🟡 high | Offers a rigorous, step-by-step curriculum for learning real-world cloud operations, infrastructure as code, and security scanning on AWS. |
+    | 2026-06-18 | [techiescamp/devops-projects:Real-World DevOps Projects For Learning](https://github.com/techiescamp/devops-projects) | 🟡 high | Provides comprehensive, real-world infrastructure blueprints and CI/CD templates essential for hands-on DevOps learning and portfolio building. |
+    | 2026-06-01 | [cheatsheetseries.owasp.org: OWASP Cheat Sheet Series 🌟🌟](https://cheatsheetseries.owasp.org/index.html) | 🟡 high | Serves as the ultimate application security reference, heavily utilized in training for the Certified Kubernetes Security Specialist (CKS) exam. |
+    | 2026-06-08 | [stefanprodan/podinfo](https://github.com/stefanprodan/podinfo) | 🟡 high | The de facto reference microservice used by engineers to practice and test Kubernetes deployment patterns, service meshes, and observability tools. |
+    | 2026-01-15 | [knative-tutorial](https://github.com/redhat-developer-demos/knative-tutorial) | 🔵 medium | Delivers a structured, practical tutorial for mastering Knative serving, eventing, and scale-to-zero serverless paradigms in Kubernetes. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -931,7 +823,40 @@ search:
     | 2026-06-01 | [terraform.io: Terraform Commands](https://developer.hashicorp.com/terraform/cli/commands) | 🔵 medium | The official HashiCorp command reference essential for mastering advanced state management, a core focus of Terraform certifications. |
     | 2026-01-15 | [knative-tutorial](https://github.com/redhat-developer-demos/knative-tutorial) | 🟡 high | An authoritative, hands-on tutorial curriculum designed to train developers on advanced cloud-native serverless paradigms using Knative. |
 
-    **AWS**
+
+## AWS
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-02 | [Get started with OpenAI GPT-5.5, GPT-5.4 models, and Codex on Amazon Bedrock](https://aws.amazon.com/blogs/aws/get-started-with-openai-gpt-5-5-gpt-5-4-models-and-codex-on-amazon-bedrock) | 🔴 critical | This landmark release brings OpenAI's frontier models natively to Amazon Bedrock, breaking previous cloud hosting monopolies and providing enterprise-grade, secure access for generative AI. |
+    | 2026-03-23 | [github.com/localstack/localstack](https://github.com/localstack/localstack) | 🔴 critical | As the premier AWS cloud emulator with massive industry adoption, LocalStack is foundational for modern, local cloud-native development and offline testing pipelines. |
+    | 2025-03-25 | [aws/containers-roadmap: AWS Containers Roadmap](https://github.com/aws/containers-roadmap) | 🟡 high | This roadmap bridges developer requirements with core AWS engineering teams, offering a transparent ledger of feature designs for Kubernetes, EKS, ECS, and ECR. |
+    | 2026-04-13 | [ermetic/access-undenied-aws 🌟](https://github.com/tenable/access-undenied-aws) | 🟡 high | This tool dramatically simplifies AWS security operations by parsing CloudTrail and 'Access Denied' errors to pinpoint the exact blocking IAM policy or SCP. |
+    | 2026-06-02 | [Introducing the next generation of Amazon OpenSearch Serverless for building your agentic AI applications](https://aws.amazon.com/blogs/aws/introducing-the-next-generation-of-amazon-opensearch-serverless-for-building-your-agentic-ai-applications) | 🟡 high | The complete separation of compute and storage in this release enables true serverless scalability and highly dynamic indexing suited for agentic AI applications. |
+    | 2026-06-09 | [awslabs/amazon-ecr-credential-helper: Amazon ECR Docker Credential Helper](https://github.com/awslabs/amazon-ecr-credential-helper) | 🟡 high | It enhances container runtime security and reliability by handling seamless IAM-based ECR authentication, removing the need for periodic token-refresh cron jobs. |
+    | 2024-04-20 | [github.com/one2nc/cloudlens 🌟](https://github.com/one2nc/cloudlens) | 🔵 medium | Acting as a 'k9s' equivalent for AWS resources, this interactive terminal UI significantly streamlines resource monitoring and navigation for cloud operators. |
+    | 2026-06-02 | [Learn AWS IAM Interactively](https://www.learnawsiam.com) | 🔵 medium | This highly interactive simulator simplifies the learning curve of complex AWS IAM policy evaluation rules directly within the browser. |
+    | 2024-08-16 | [The Open Guide to Amazon Web Services](https://github.com/open-guides/og-aws) | 🔵 medium | This massive, crowd-sourced encyclopedia provides unvarnished, real-world engineering constraints and design trade-offs that official AWS documentation often omits. |
+    | 2026-06-13 | [awslabs/aws-cloudsaga: AWS CloudSaga - Simulate security events in AWS](https://github.com/awslabs/aws-cloudsaga) | 🔵 medium | This open-source tool from AWS Labs enables security operations teams to validate detection capabilities by simulating malicious security events natively. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-02 | [Get started with OpenAI GPT-5.5, GPT-5.4 models, and Codex on Amazon Bedrock](https://aws.amazon.com/blogs/aws/get-started-with-openai-gpt-5-5-gpt-5-4-models-and-codex-on-amazon-bedrock) | 🔴 critical | Marks a major industry paradigm shift by bringing OpenAI's frontier models to AWS Bedrock, ending Microsoft's exclusive hosting agreement. |
+    | 2026-03-23 | [github.com/localstack/localstack](https://github.com/localstack/localstack) | 🔴 critical | Remains the absolute industry standard for local AWS emulation, enabling rapid, cost-effective cloud-native testing and development. |
+    | 2025-03-25 | [aws/containers-roadmap: AWS Containers Roadmap](https://github.com/aws/containers-roadmap) | 🔴 critical | Provides crucial transparency and direct community collaboration on the engineering roadmap for AWS container services like EKS and ECS. |
+    | 2026-06-02 | [Introducing the next generation of Amazon OpenSearch Serverless for building your agentic AI applications](https://aws.amazon.com/blogs/aws/introducing-the-next-generation-of-amazon-opensearch-serverless-for-building-your-agentic-ai-applications) | 🟡 high | Introduces a rebuilt serverless search architecture that completely decouples compute and storage for modern agentic AI workloads. |
+    | 2026-04-13 | [ermetic/access-undenied-aws 🌟](https://github.com/tenable/access-undenied-aws) | 🟡 high | Significantly simplifies AWS IAM troubleshooting by parsing Access Denied errors and pinpointing the exact blocking policy or SCP. |
+    | 2024-08-16 | [The Open Guide to Amazon Web Services](https://github.com/open-guides/og-aws) | 🟡 high | Serves as an indispensable, community-driven guide that exposes real-world AWS engineering constraints and unvarnished operational realities. |
+    | 2025-05-01 | [Metabadger](https://github.com/salesforce/metabadger) | 🟡 high | Automates the critical security hardening of EC2 instances by systematically enforcing IMDSv2 to prevent SSRF exploitation. |
+    | 2024-01-09 | [saml-to/assume-aws-role-action](https://github.com/saml-to/assume-aws-role-action) | 🟡 high | Enhances CI/CD pipeline security by leveraging OIDC to assume AWS IAM roles, eliminating the need for risky long-lived static credentials. |
+    | 2026-06-02 | [From Silos to Service Topology: Why Netflix Built a Real-Time Service Map](https://netflixtechblog.com/from-silos-to-service-topology-why-netflix-built-a-real-time-service-map-0165ba13a7bc?source=rss----2615bd06b42e---4) | 🟡 high | Demonstrates next-generation observability by correlating eBPF network flows with service registries to map complex microservice architectures. |
+    | 2026-06-13 | [awslabs/aws-cloudsaga: AWS CloudSaga - Simulate security events in AWS](https://github.com/awslabs/aws-cloudsaga) | 🟡 high | Enables security operations teams to validate detection mechanisms by simulating malicious activities directly inside AWS environments. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -946,7 +871,40 @@ search:
     | 2024-08-16 | [The Open Guide to Amazon Web Services](https://github.com/open-guides/og-aws) | 🔵 medium | Provides an invaluable, unvarnished community-driven encyclopedia detailing real-world engineering constraints and pricing gotchas of AWS services. |
     | 2024-04-20 | [github.com/one2nc/cloudlens 🌟](https://github.com/one2nc/cloudlens) | 🔵 medium | Acts as a k9s equivalent for AWS, providing a highly interactive terminal UI to easily monitor and navigate complex cloud infrastructure. |
 
-    **Azure**
+
+## Azure
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [github.com/microsoft/CBL-Mariner](https://github.com/microsoft/azurelinux) | 🔴 critical | It acts as the secure, container-optimized base OS for Azure Kubernetes Service, minimizing footprint and maximizing security for cloud-native workloads. |
+    | 2026-06-05 | [github.com/Azure/apiops 🌟](https://github.com/Azure/apiops) | 🟡 high | It brings GitOps principles to Azure API Management, enabling teams to automate the configuration and deployment of API gateways. |
+    | 2026-06-01 | [floci-az](https://github.com/floci-io/floci-az) | 🟡 high | It drastically simplifies the local development loop for cloud-native engineers by emulating core Azure services, including AKS and Functions, on a single local port. |
+    | 2026-06-02 | [From Prompt to Production: Open in VS Code for Terraform in Azure Copilot](https://techcommunity.microsoft.com/blog/azuretoolsblog/from-prompt-to-production-open-in-vs-code-for-terraform-in-azure-copilot/4494931) | 🟡 high | It merges generative AI with modern IaC practices by allowing developers to generate and open Terraform manifests directly from Azure Copilot in VS Code. |
+    | 2026-06-02 | [Azure Hub-and-Spoke Generally Available for HCP Vault Dedicated](https://www.hashicorp.com/blog/azure-hub-and-spoke-generally-available-for-hcp-vault-dedicated) | 🟡 high | It bridges enterprise secret management and secure networking by enabling managed HashiCorp Vault deployments within standard Azure hub-and-spoke architectures. |
+    | 2025-01-14 | [github.com/azure/mission-critical-online: Welcome to Azure Mission-Critical' Online Reference Implementation](https://github.com/azure/mission-critical-online) | 🟡 high | It provides an industry-grade architectural blueprint for building resilient, zero-downtime, active-active cloud applications on Azure. |
+    | 2026-06-01 | [azurearcjumpstart.io](https://jumpstart.azure.com) | 🟡 high | It streamlines hybrid cloud-native testing by providing instant, automated sandbox environments for Azure Arc-enabled Kubernetes. |
+    | 2026-06-02 | [Azure Update 22nd May 2026](https://www.youtube.com/watch?v=pMfG-vYvnv8&feature=youtu.be) | 🔵 medium | This update highlights critical cloud-native advancements, specifically the automatic instrumentation of Azure Kubernetes Service with Application Insights. |
+    | 2026-06-10 | [github.com/microsoft/finops-toolkit](https://github.com/microsoft/finops-toolkit) | 🔵 medium | It delivers the foundational open-source toolset for organizations to automate, standardize, and govern cloud financial operations across Azure. |
+    | 2026-06-14 | [Bicep](https://github.com/Azure/bicep) | 🟡 high | It serves as the premier native declarative infrastructure-as-code solution for Azure, simplifying resource provisioning over complex ARM templates. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [github.com/microsoft/CBL-Mariner](https://github.com/microsoft/azurelinux) | 🔴 critical | Delivers a lightweight, highly secure, container-optimized base OS purpose-built to minimize the attack surface of AKS workloads. |
+    | 2026-06-14 | [Bicep](https://github.com/Azure/bicep) | 🟡 high | Acts as the standard, developer-friendly declarative alternative to raw ARM templates for modular and validated Azure infrastructure provisioning. |
+    | 2026-06-10 | [github.com/microsoft/finops-toolkit](https://github.com/microsoft/finops-toolkit) | 🟡 high | Standardizes enterprise cost governance by orchestrating Azure compute optimizations, amortization data, and Power BI dashboards in one toolkit. |
+    | 2026-06-05 | [github.com/Azure/apiops 🌟](https://github.com/Azure/apiops) | 🟡 high | Brings GitOps automation to Azure API Management, allowing teams to seamlessly extract, publish, and control API configurations. |
+    | 2026-06-01 | [azurearcjumpstart.io](https://jumpstart.azure.com) | 🟡 high | Provides a vital, fully automated sandbox framework to accelerate the evaluation and deployment of hybrid Azure Arc-enabled Kubernetes. |
+    | 2026-01-13 | [github.com/mspnp/AzureNamingTool - Azure Naming Tool 🌟](https://github.com/mspnp/AzureNamingTool) | 🔵 medium | Enforces platform engineering discipline by programmatically standardizing resource naming conventions across global enterprise deployments. |
+    | 2025-01-14 | [github.com/azure/mission-critical-online: Welcome to Azure Mission-Critical' Online Reference Implementation](https://github.com/azure/mission-critical-online) | 🔴 critical | Defines the industry gold-standard reference architecture for deploying active-active, zero-downtime microservices on Azure infrastructure. |
+    | 2026-06-02 | [Azure Update 22nd May 2026](https://www.youtube.com/watch?v=pMfG-vYvnv8&feature=youtu.be) | 🟡 high | Highlights critical updates like automatic AKS observability instrumentation and native Cosmos DB support for LangChain AI orchestration. |
+    | 2026-06-02 | [From Prompt to Production: Open in VS Code for Terraform in Azure Copilot](https://techcommunity.microsoft.com/blog/azuretoolsblog/from-prompt-to-production-open-in-vs-code-for-terraform-in-azure-copilot/4494931) | 🔵 medium | Bridges conversational cloud operations and local workflow execution by generating exportable Terraform manifests directly from Azure Copilot. |
+    | 2026-06-02 | [Azure Hub-and-Spoke Generally Available for HCP Vault Dedicated](https://www.hashicorp.com/blog/azure-hub-and-spoke-generally-available-for-hcp-vault-dedicated) | 🟡 high | Bridges cloud-native security and enterprise networking by enabling managed HashiCorp Vault to natively hook into Azure Hub-and-Spoke layouts. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -961,7 +919,40 @@ search:
     | 2026-06-02 | [Azure Hub-and-Spoke Generally Available for HCP Vault Dedicated](https://www.hashicorp.com/blog/azure-hub-and-spoke-generally-available-for-hcp-vault-dedicated) | 🟡 high | Simplifies zero-trust secrets management by offering native, managed HashiCorp Vault integration in enterprise Hub-and-Spoke network layouts. |
     | 2026-06-02 | [Azure Update 15th May 2026](https://www.youtube.com/watch?v=tfoSeH63yCg&list=PLOU2XLYxmsIKL_eEgkKJWDRhYUEvS9eYz&index=1&pp=iAQB) | 🟡 high | Announces key developer updates in serverless containers, including Azure Container Apps Express and virtual node enhancements. |
 
-    **GCP, OCI & Others**
+
+## GCP, OCI & Others
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [github.com/GoogleCloudPlatform/k8s-config-connector: GCP Config Connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) | 🟡 high | Enables declarative GitOps workflows by allowing engineering teams to manage Google Cloud resources directly through native Kubernetes Custom Resource Definitions. |
+    | 2026-06-13 | [Google Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpacks) | 🟡 high | Streamlines the containerization pipeline by automatically translating source code into secure, production-ready OCI images without requiring Dockerfile maintenance. |
+    | 2026-05-17 | [github.com/oracle](https://github.com/oracle) | 🟡 high | Houses the foundational Cloud Controller Manager and CSI storage plugins necessary for running production-grade Kubernetes clusters on Oracle Cloud Infrastructure. |
+    | 2026-06-18 | [engineering.mercari.com: Kubernetes based autoscaler for Cloud Spanner](https://engineering.mercari.com/en/blog/entry/20211222-kubernetes-based-spanner-autoscaler) | 🔵 medium | Offers a highly practical, real-world architectural reference for building custom Kubernetes-native autoscalers to manage external managed databases like Cloud Spanner. |
+    | 2026-06-14 | [Red Hat's approach to Edge Computing 🌟](https://www.redhat.com/en/solutions/edge-computing-approach) | 🟡 high | Pushes the cloud-native frontier into edge computing using single-node OpenShift and MicroShift architectures for low-latency, disconnected operations. |
+    | 2026-06-14 | [A hybrid cloud-native DevSecOps pipeline with JFrog Artifactory and GKE on-prem 🌟](https://docs.cloud.google.com/architecture) | 🟡 high | Delivers an enterprise-grade hybrid blueprint for secure container lifecycles by pairing GKE on-prem with JFrog Artifactory. |
+    | 2026-06-01 | [cloud.google.com: Choose the best way to use and authenticate service accounts on Google Cloud](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) | 🔴 critical | Establishes critical security protocols for GKE deployments, strongly advocating for Workload Identity over high-risk, static service account JSON keys. |
+    | 2026-06-01 | [cloud.google.com: Consume services faster, privately and securely - Private Service Connect now in GA](https://cloud.google.com/blog/products/networking/private-service-connect-is-now-generally-available) | 🔴 critical | Re-architects enterprise cloud networking by allowing private, secure connections across disjointed VPC networks and SaaS providers without public internet exposure. |
+    | 2026-06-01 | [cloud.google.com: Microservices architecture on Google Cloud](https://cloud.google.com/blog/topics/developers-practitioners/microservices-architecture-google-cloud) | 🟡 high | Provides the definitive reference guide for structuring, deploying, and securing enterprise microservices using GKE and Anthos Service Mesh. |
+    | 2026-06-01 | [OpenShift in Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/openshift-container-platform-4x) | 🟡 high | Bridges multi-cloud boundaries by providing a fully managed, joint-engineered OpenShift platform natively integrated within Microsoft Azure's infrastructure. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-14 | [github.com/GoogleCloudPlatform/k8s-config-connector: GCP Config Connector](https://github.com/GoogleCloudPlatform/k8s-config-connector) | 🔴 critical | Bridges declarative Kubernetes APIs with Google Cloud resource management, enabling standard GitOps-driven infrastructure provisioning. |
+    | 2026-06-01 | [cloud.google.com: Choose the best way to use and authenticate service accounts on Google Cloud](https://cloud.google.com/blog/products/identity-security/how-to-authenticate-service-accounts-to-help-keep-applications-secure) | 🔴 critical | Secures Kubernetes workloads on GCP by leveraging Workload Identity, eliminating the high risk of managing long-lived service account keys. |
+    | 2026-06-13 | [Google Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpacks) | 🟡 high | Automates the generation of secure, OCI-compliant container images directly from source code, standardizing cloud-native build pipelines. |
+    | 2026-05-17 | [github.com/oracle](https://github.com/oracle) | 🟡 high | Hosts the core open-source integrations like Cloud Controller Manager and CSI storage plugins necessary for enterprise Kubernetes on OCI. |
+    | 2026-06-18 | [engineering.mercari.com: Kubernetes based autoscaler for Cloud Spanner](https://engineering.mercari.com/en/blog/entry/20211222-kubernetes-based-spanner-autoscaler) | 🟡 high | Demonstrates advanced cloud-native patterns by utilizing custom Kubernetes controllers to dynamically autoscale Cloud Spanner based on workload metrics. |
+    | 2026-06-14 | [Red Hat's approach to Edge Computing 🌟](https://www.redhat.com/en/solutions/edge-computing-approach) | 🟡 high | Addresses the key operational challenge of deploying cloud-native workloads to resource-constrained edge environments using MicroShift. |
+    | 2026-06-14 | [A hybrid cloud-native DevSecOps pipeline with JFrog Artifactory and GKE on-prem 🌟](https://docs.cloud.google.com/architecture) | 🟡 high | Establishes a comprehensive, secure DevSecOps framework for enterprise environments utilizing GKE on-premises and hybrid cloud architectures. |
+    | 2026-06-01 | [cloud.google.com: Consume services faster, privately and securely - Private Service Connect now in GA](https://cloud.google.com/blog/products/networking/private-service-connect-is-now-generally-available) | 🟡 high | Simplifies multi-tenant and cross-organization cloud networking by facilitating secure, private service connections without complex VPN infrastructure. |
+    | 2026-06-01 | [OpenShift in Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/openshift-container-platform-4x) | 🟡 high | Delivers a fully managed, jointly engineered enterprise OpenShift platform that bridges Red Hat ecosystems with native public cloud infrastructure. |
+    | 2026-06-01 | [cloud.google.com: Microservices architecture on Google Cloud](https://cloud.google.com/blog/topics/developers-practitioners/microservices-architecture-google-cloud) | 🔵 medium | Serves as a vital reference blueprint for engineering teams modeling secure microservices networks using GKE and Anthos Service Mesh. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -976,7 +967,40 @@ search:
     | 2026-06-13 | [Google Cloud Buildpacks](https://github.com/GoogleCloudPlatform/buildpacks) | 🟡 high | Standardizes and simplifies OCI container image creation directly from source code without requiring Dockerfiles on GCP runtimes. |
     | 2026-06-14 | [scaleway.com: Kubernetes Kapsule](https://www.scaleway.com/en/en/kubernetes-kapsule) | 🔵 medium | Provides a vital managed Kubernetes alternative for European enterprises prioritizing sovereign cloud infrastructure and dynamic volume provisioning. |
 
-    **OpenShift / Red Hat**
+
+## OpenShift / Red Hat
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-12 | [github.com/openshift/hypershift: HyperShift](https://github.com/openshift/hypershift) | 🔴 critical | Decouples and containerizes the OpenShift control plane, initiating a massive paradigm shift towards faster, more cost-effective multi-cluster management. |
+    | 2026-06-01 | [Amazon Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift/aws) | 🔴 critical | Offloads operational complexity through a fully managed, jointly supported native service on AWS, driving massive enterprise adoption. |
+    | 2026-06-11 | [Red Hat OLM](https://github.com/operator-framework/operator-lifecycle-manager) | 🔴 critical | Acts as the standard orchestrator for managing the lifecycle, dependencies, and updates of enterprise operators across any Kubernetes cluster. |
+    | 2026-06-18 | [OpenShift 4 documentation 🌟](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22) | 🔴 critical | Serving as the definitive operational manual for version 4.22, it provides critical guidance on lifecycle management and security policies for production clusters. |
+    | 2026-06-14 | [github.com/openshift/installer openshift installer 🌟](https://github.com/openshift/installer) | 🔴 critical | As the engine behind IPI/UPI installations, it standardizes automated, infrastructure-aware bootstrapping of OpenShift clusters across cloud providers. |
+    | 2026-06-01 | [ARO](https://www.redhat.com/en/technologies/cloud-computing/openshift/azure) | 🔴 critical | Enables seamless, co-engineered Azure integrations and unified billing, making it a leading choice for enterprise hybrid cloud deployments. |
+    | 2026-06-09 | [Machine API](https://github.com/openshift/machine-api-operator/tree/main) | 🟡 high | Enables true declarative node scaling and self-healing lifecycle management by natively integrating Cluster API patterns inside OpenShift. |
+    | 2026-06-08 | [github.com/redhat-cop/gitops-catalog](https://github.com/redhat-cop/gitops-catalog) | 🟡 high | Provides production-grade, community-validated GitOps templates and Argo CD blueprints crucial for automating enterprise cluster configurations. |
+    | 2026-06-18 | [Developer Sandbox](https://developers.redhat.com/developer-sandbox) | 🟡 high | Provides zero-cost, immediate access to fully configured OpenShift environments, dramatically lowering the barrier to entry for cloud-native developers. |
+    | 2026-06-11 | [GitHub: OKD4](https://github.com/okd-project/okd/blob/master/README.md) | 🟡 high | Represents the vital open-source upstream community distribution that bridges Fedora CoreOS with advanced cloud-native features. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-12 | [github.com/openshift/hypershift: HyperShift](https://github.com/openshift/hypershift) | 🔴 critical | HyperShift introduces a major paradigm shift by hosting the OpenShift control plane as containerized workloads, drastically reducing cost and deployment time. |
+    | 2026-06-01 | [Amazon Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift/aws) | 🔴 critical | ROSA is a cornerstone of hybrid-cloud enterprise strategy, delivering a fully-managed, native OpenShift experience directly integrated into AWS. |
+    | 2026-06-08 | [github.com/redhat-cop/gitops-catalog](https://github.com/redhat-cop/gitops-catalog) | 🟡 high | This community-curated collection of GitOps blueprints provides production-ready templates that standardize enterprise application delivery on OpenShift. |
+    | 2026-06-11 | [Red Hat OLM](https://github.com/operator-framework/operator-lifecycle-manager) | 🟡 high | Operator Lifecycle Manager is the foundational orchestrator powering OpenShift's operator-first architecture and automated cluster upgrades. |
+    | 2026-06-14 | [github.com/openshift/installer openshift installer 🌟](https://github.com/openshift/installer) | 🟡 high | The OpenShift Installer is the core engine responsible for automated, production-grade cluster bootstrapping across diverse cloud infrastructures. |
+    | 2026-06-09 | [Machine API](https://github.com/openshift/machine-api-operator/tree/main) | 🟡 high | The Machine API Operator brings cloud-native declarative management to underlying cluster nodes, enabling automated scaling and lifecycle operations. |
+    | 2026-06-01 | [ARO](https://www.redhat.com/en/technologies/cloud-computing/openshift/azure) | 🟡 high | ARO provides a crucial co-engineered, managed OpenShift service on Azure, allowing enterprises to seamlessly run complex containerized workloads. |
+    | 2026-06-01 | [OpenShift Serverless](https://www.redhat.com/en/technologies/cloud-computing/openshift/serverless) | 🟡 high | OpenShift Serverless natively embeds Knative into the platform, providing developers with scale-to-zero capabilities and event-driven automation. |
+    | 2026-06-18 | [OpenShift 4 documentation 🌟](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22) | 🔵 medium | As the official documentation for the latest releases, this resource is the authoritative guide for cluster administrators managing enterprise configurations. |
+    | 2026-06-11 | [GitHub: OKD4](https://github.com/okd-project/okd/blob/master/README.md) | 🔵 medium | OKD4 represents the essential upstream open-source community distribution of OpenShift, serving as the proving ground for cloud-native innovation. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |
@@ -991,7 +1015,40 @@ search:
     | 2026-06-18 | [Developer Sandbox](https://developers.redhat.com/developer-sandbox) | 🟡 high | The Developer Sandbox eliminates infrastructure friction by giving developers instant, zero-cost access to pre-configured OpenShift environments. |
     | 2026-06-12 | [github.com/openshift/origin 🌟](https://github.com/openshift/origin) | 🟡 high | As the upstream open-source core of OpenShift, OKD drives the community-led innovation and features that eventually graduate into the enterprise product. |
 
-    **Virtualization & Private Cloud**
+
+## Virtualization & Private Cloud
+
+=== "Last 3 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [ClusterAPI](https://cluster-api.sigs.k8s.io) | 🔴 critical | Cluster API standardizes declarative, Kubernetes-style lifecycle management of clusters across private hypervisors and bare metal. |
+    | 2026-06-14 | [Openshift Container Platform](https://nubenetes.com/openshift) | 🔴 critical | Red Hat OpenShift remains the premier enterprise platform integrating traditional virtualization with modern cloud-native workloads. |
+    | 2026-06-14 | [Rancher: Enterprise management for Kubernetes](https://nubenetes.com/rancher) | 🔴 critical | Rancher provides a unified, highly adopted control plane to simplify heterogeneous cluster operations on private and bare-metal servers. |
+    | 2026-06-14 | [**Kubespray**](https://github.com/kubernetes-sigs/kubespray) | 🟡 high | Kubespray offers the most flexible, production-grade Ansible automation for deploying Kubernetes clusters on existing private cloud infrastructure. |
+    | 2025-12-05 | [Kubeinit 🌟](https://github.com/kubeinit/kubeinit) | 🟡 high | Kubeinit specifically addresses the virtualization space by automating K8s and OpenShift deployments on KVM/libvirt hypervisors. |
+    | 2026-06-12 | [defenseunicorns/zarf](https://github.com/zarf-dev/zarf) | 🟡 high | Zarf simplifies the packaging and deployment of secure, cloud-native apps into highly restricted and disconnected private cloud environments. |
+    | 2026-06-01 | [Kubernetes Cluster with **Kubeadm**](https://github.com/kubernetes/kubeadm) | 🟡 high | Kubeadm serves as the official, foundational bootstrapping engine that drives node onboarding and cluster building in private cloud environments. |
+    | 2026-06-01 | [Nomad](https://developer.hashicorp.com/nomad) | 🟡 high | Nomad is a powerful, lightweight alternative to Kubernetes that simplifies scheduling virtualized and containerized workloads across private infrastructure. |
+    | 2026-06-13 | [K0s - Zero Friction Kubernetes](https://github.com/k0sproject/k0s) | 🔵 medium | k0s reduces operational friction by packaging a fully compliant, enterprise-grade Kubernetes control plane into a single binary ideal for private cloud edge. |
+    | 2026-06-01 | [kurl.sh](https://kurl.sh) | 🔵 medium | kurl.sh allows enterprises to build custom, production-ready Kubernetes installers tailored specifically for air-gapped private cloud deployments. |
+
+=== "Last 6 Months"
+
+    | Date | Resource | Impact | Why It Matters |
+    | :--- | :--- | :---: | :--- |
+    | 2026-06-01 | [ClusterAPI](https://cluster-api.sigs.k8s.io) | 🔴 critical | Enables declarative, API-driven lifecycle management of Kubernetes clusters across diverse virtualization and bare-metal environments. |
+    | 2026-06-14 | [Openshift Container Platform](https://nubenetes.com/openshift) | 🔴 critical | Acts as a market-leading enterprise hybrid platform with native virtualization support for running VMs alongside containers. |
+    | 2026-06-14 | [Rancher: Enterprise management for Kubernetes](https://nubenetes.com/rancher) | 🔴 critical | Simplifies management and operations of multi-cluster Kubernetes deployments on private cloud and bare-metal architectures. |
+    | 2026-06-14 | [**Kubespray**](https://github.com/kubernetes-sigs/kubespray) | 🟡 high | Provides the industry-standard Ansible automation necessary to configure and deploy production-ready clusters on-premises. |
+    | 2026-06-12 | [defenseunicorns/zarf](https://github.com/zarf-dev/zarf) | 🟡 high | Enables highly secure cloud-native application delivery in strictly air-gapped and disconnected private cloud environments. |
+    | 2025-12-05 | [Kubeinit 🌟](https://github.com/kubeinit/kubeinit) | 🟡 high | Automates the deployment of enterprise Kubernetes distributions specifically targeted at libvirt/KVM virtualization infrastructures. |
+    | 2026-05-17 | [**VMware Kubernetes Tanzu**](https://cloud.vmware.com/tanzu) | 🟡 high | Seamlessly integrates cloud-native container orchestration with industry-standard VMware vSphere virtualization infrastructure. |
+    | 2026-06-01 | [Nomad](https://developer.hashicorp.com/nomad) | 🟡 high | Offers a lightweight, operationally simple alternative to Kubernetes for managing virtualized and bare-metal workloads at scale. |
+    | 2026-06-08 | [poseidon/typhoon](https://github.com/poseidon/typhoon) | 🔵 medium | Leverages Terraform to provide a secure, minimalist approach to bootstrapping upstream Kubernetes on bare-metal systems. |
+    | 2026-06-18 | [cncf.io webinar: Deploying Kubernetes to bare metal using cluster API](https://www.cncf.io/online-programs/deploying-kubernetes-to-bare-metal-using-cluster-api) | 🔵 medium | Details the strategic use of Cluster API to bring cloud-native declarative operations directly to bare-metal deployments. |
+
+=== "Last 12 Months"
 
     | Date | Resource | Impact | Why It Matters |
     | :--- | :--- | :---: | :--- |


### PR DESCRIPTION
## Problem
The **Intelligence Digest** pages (Tech & Cloud, Industry & Geo) showed nothing in the right-hand "On this page" TOC. They were rendered *period-first*: three time-window tabs (`=== "Last 3/6/12 Months"`), each nesting every category as **bold text** (`**Kubernetes & Orchestration**`). Bold text isn't a heading, so the pages had **zero headings** → empty TOC. (The bold-instead-of-heading was itself an MD023 workaround for indented `##` inside tabs.)

## Fix — invert to category-first
`_generate_digest_pages()` now emits each category as a real `##` heading at column 0, with the three time-windows as content tabs **inside** each category:
```
## Kubernetes & Orchestration
=== "Last 3 Months"
    | table |
=== "Last 6 Months"
    | table |
```
- Right TOC now lists all **22 tech categories** / **4 geo regions**, once each.
- Headings at column 0 → MD023 workaround no longer needed (pre-commit schema check: 0 errors).
- Tabbed time-window UX preserved (22 `tabbed-set`s render correctly).

## Verification
- Regenerated both pages from the live `news_digest.json`; `mkdocs build -f v2-mkdocs.yml` → exit 0.
- `tech-digest`: 22 category anchors in the secondary TOC; `industry-digest`: Americas / Europe / Spain / Asia-Pacific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)