### PR TITLE
fix(v2): Topic Map dimensions must be h2 not h3 (MD001 lint failure)

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1226,8 +1226,9 @@ input[type="text"] {
   width: 100%;
   margin: 0 0 1.4rem;
 }
-.topic-map-dim h3 {
+.topic-map-dim h2 {
   margin-top: 0;
+  font-size: 1.05rem;
 }
 .topic-map-dim ul {
   margin-top: 0.3rem;

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1199,7 +1199,10 @@ class V2VisionEngine:
         for dim in self.dimensions.keys():
             if dim in dim_groups:
                 topic_md += "<section class=\"topic-map-dim\" markdown=\"1\">\n\n"
-                topic_md += f"### {dim}\n\n"
+                # h2 (not h3): the page H1 is "Topic Map", so dimensions must
+                # increment by one level (markdownlint MD001). Also gives the
+                # right-hand TOC a clean per-dimension index.
+                topic_md += f"## {dim}\n\n"
                 for f in sorted(dim_groups[dim]):
                     count = _count_links(data[f]["content"])
                     topic_md += f"- **[{data[f]['title']}](./{f})** <span class=\"topic-count\">{count}</span>\n"

--- a/v2-docs/topic-map.md
+++ b/v2-docs/topic-map.md
@@ -7,7 +7,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### AI
+## AI
 
 - **[AI Agents MCP](./ai-agents-mcp.md)** <span class="topic-count">4</span>
 - **[AI](./ai.md)** <span class="topic-count">11</span>
@@ -18,7 +18,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Architectural Foundations
+## Architectural Foundations
 
 - **[About](./about.md)** <span class="topic-count">4</span>
 - **[Cheatsheets](./cheatsheets.md)** <span class="topic-count">14</span>
@@ -46,7 +46,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Platform & Site Reliability
+## Platform & Site Reliability
 
 - **[Chaos Engineering](./chaos-engineering.md)** <span class="topic-count">20</span>
 - **[Developerportals](./developerportals.md)** <span class="topic-count">38</span>
@@ -64,7 +64,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Hardened Infrastructure
+## Hardened Infrastructure
 
 - **[Ansible](./ansible.md)** <span class="topic-count">15</span>
 - **[Devsecops](./devsecops.md)** <span class="topic-count">137</span>
@@ -79,7 +79,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Cloud Providers (Hyperscalers)
+## Cloud Providers (Hyperscalers)
 
 - **[Googlecloudplatform](./GoogleCloudPlatform.md)** <span class="topic-count">33</span>
 - **[AWS Architecture](./aws-architecture.md)** <span class="topic-count">3</span>
@@ -110,7 +110,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Networking & Service Mesh
+## Networking & Service Mesh
 
 - **[Caching](./caching.md)** <span class="topic-count">3</span>
 - **[Cloudflare](./cloudflare.md)** <span class="topic-count">3</span>
@@ -123,7 +123,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### The Container Stack
+## The Container Stack
 
 - **[Container Managers](./container-managers.md)** <span class="topic-count">21</span>
 - **[Docker](./docker.md)** <span class="topic-count">28</span>
@@ -150,7 +150,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Data & Advanced Analytics
+## Data & Advanced Analytics
 
 - **[Crunchydata](./crunchydata.md)** <span class="topic-count">12</span>
 - **[Databases](./databases.md)** <span class="topic-count">46</span>
@@ -162,7 +162,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Engineering Pipeline
+## Engineering Pipeline
 
 - **[Argo](./argo.md)** <span class="topic-count">14</span>
 - **[CI/CD Kubernetes Plugins](./cicd-kubernetes-plugins.md)** <span class="topic-count">1</span>
@@ -181,7 +181,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Developer Ecosystem
+## Developer Ecosystem
 
 - **[Angular](./angular.md)** <span class="topic-count">1</span>
 - **[API](./api.md)** <span class="topic-count">53</span>
@@ -203,7 +203,7 @@
 
 <section class="topic-map-dim" markdown="1">
 
-### Career & Industry
+## Career & Industry
 
 - **[Appointment Scheduling](./appointment-scheduling.md)** <span class="topic-count">1</span>
 - **[Elearning](./elearning.md)** <span class="topic-count">3</span>

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -104,7 +104,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.16
+  - static/v2_elite.css?v=2.9.17
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.12


### PR DESCRIPTION
## Problem
After v2.9.16, **07.2 Markdown Linter** failed on `develop` and `master`:
```
v2-docs/topic-map.md:10 MD001/heading-increment — Expected: h2; Actual: h3
```
The Topic Map page H1 is `# Topic Map`, so emitting dimensions as `### {dim}` skipped a level.

## Fix
- `v2_optimizer.py`: generate dimension headings as **`## {dim}`** (h2).
- `v2-docs/topic-map.md`: committed page corrected to h2 (preserves the publisher's fresh counts/names).
- `v2_elite.css`: selector `.topic-map-dim h2` (+ size); cache-bust `?v=2.9.17`.

Bonus: h2 dimensions now populate the right-hand "On this page" TOC of the Topic Map with a clean per-dimension index.

## Validation
- `markdownlint-cli2` with the **exact CI config** → **0 errors**.
- Pre-commit markdown schema check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)