### PR TITLE
feat(v2/nav): expand quick-nav with ten principal topic flagships

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -9,6 +9,11 @@
   block, which is empty here since navigation.tabs is disabled). Gives the key
   cross-cutting destinations a persistent, one-click home — without the
   18-tab overflow and without collapsing the full left navigation tree.
+
+  Layout: discovery/meta hubs, then the cloud-native pillar topics
+  (orchestration · containers · delivery · infra · security · observability)
+  plus the ops disciplines (SRE · DevOps), then the AI hubs (AI & MCP · MLOps)
+  and Methodology, with V1 Archive muted at the far right.
 -#}
 {% block tabs %}
 <nav class="nb-quicknav" aria-label="Quick navigation">
@@ -16,7 +21,17 @@
     <a class="nb-quicknav__link" href="/topic-map/">🗺️ Topic Map</a>
     <a class="nb-quicknav__link" href="/tech-digest/">📊 Intelligence Digest</a>
     <a class="nb-quicknav__link" href="/videos/">🎥 Video Hub</a>
+    <a class="nb-quicknav__link" href="/kubernetes/">☸️ Kubernetes</a>
+    <a class="nb-quicknav__link" href="/docker/">🐳 Docker</a>
+    <a class="nb-quicknav__link" href="/gitops/">🔄 GitOps</a>
+    <a class="nb-quicknav__link" href="/terraform/">🏗️ Terraform</a>
+    <a class="nb-quicknav__link" href="/kubernetes-security/">🔐 K8s Security</a>
+    <a class="nb-quicknav__link" href="/monitoring/">📈 Observability</a>
+    <a class="nb-quicknav__link" href="/sre/">🛠️ SRE</a>
+    <a class="nb-quicknav__link" href="/devops/">♾️ DevOps</a>
+    <a class="nb-quicknav__link" href="/message-queue/">📨 Message Queue</a>
     <a class="nb-quicknav__link" href="/ai-agents-mcp/">🤖 AI &amp; MCP</a>
+    <a class="nb-quicknav__link" href="/mlops/">🧠 MLOps</a>
     <a class="nb-quicknav__link" href="/methodology/">📐 Methodology</a>
     <a class="nb-quicknav__link nb-quicknav__link--muted" href="/v1/">📚 V1 Archive</a>
   </div>


### PR DESCRIPTION
## Summary

Expands the slim quick-nav bar (added in v2.9.27) from 6 to **16 curated destinations**, surfacing the principal topics across all of Nubenetes so they're reachable in one click from any page at any depth.

### New destinations
- **Cloud-native pillars**: ☸️ Kubernetes · 🐳 Docker · 🔄 GitOps · 🏗️ Terraform · 🔐 K8s Security · 📈 Observability
- **Ops disciplines**: 🛠️ SRE · ♾️ DevOps
- **Data/messaging**: 📨 Message Queue
- **AI/ML**: 🧠 MLOps (next to the existing 🤖 AI & MCP hub)

### Resulting bar
`🗺️ Topic Map · 📊 Intelligence Digest · 🎥 Video Hub · ☸️ Kubernetes · 🐳 Docker · 🔄 GitOps · 🏗️ Terraform · 🔐 K8s Security · 📈 Observability · 🛠️ SRE · ♾️ DevOps · 📨 Message Queue · 🤖 AI & MCP · 🧠 MLOps · 📐 Methodology · [📚 V1 Archive →]`

## Notes
- Template-only change to `docs/overrides/main.html`; no CSS change, no page regeneration, V2-only.
- Reuses the existing `.nb-quicknav__link` styling; `flex-wrap` handles density on narrow viewports.
- 16 destinations — still under the 18-tab overflow line the bar was designed to avoid.
- All target pages verified to exist; `mkdocs build -f v2-mkdocs.yml` passes and all 16 links render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)