### PR TITLE
feat(v2/nav): add networking cluster + DevSecOps to quick-nav

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -14,7 +14,8 @@
   (even when the underlying page title is long):
     discovery (Topic Map · Digest · Videos) → platform (Kubernetes · Docker)
     → delivery (GitOps · CI/CD) → IaC (Terraform · Ansible)
-    → cloud (AWS · Azure · GCP) → security → ops (Observability · SRE · DevOps)
+    → cloud (AWS · Azure · GCP) → networking (Networking · Istio · K8s Net)
+    → security (Security · DevSecOps) → ops (Observability · SRE · DevOps)
     → data (Messaging) → AI/ML (AI & MCP · MLOps) → Methodology,
   with V1 Archive muted last.
 -#}
@@ -33,7 +34,11 @@
     <a class="nb-quicknav__link" href="/aws/">☁️ AWS</a>
     <a class="nb-quicknav__link" href="/azure/">☁️ Azure</a>
     <a class="nb-quicknav__link" href="/GoogleCloudPlatform/">☁️ GCP</a>
+    <a class="nb-quicknav__link" href="/networking/">🌐 Networking</a>
+    <a class="nb-quicknav__link" href="/istio/">🕸️ Istio</a>
+    <a class="nb-quicknav__link" href="/kubernetes-networking/">🔗 K8s Net</a>
     <a class="nb-quicknav__link" href="/kubernetes-security/">🔐 Security</a>
+    <a class="nb-quicknav__link" href="/devsecops/">🛡️ DevSecOps</a>
     <a class="nb-quicknav__link" href="/monitoring/">📈 Observability</a>
     <a class="nb-quicknav__link" href="/sre/">🛠️ SRE</a>
     <a class="nb-quicknav__link" href="/devops/">♾️ DevOps</a>


### PR DESCRIPTION
## Summary

Grows the quick-nav bar to **25 destinations**, following the same pattern as the v2.9.29 redesign (category-grouped, short labels, pill chips).

### New destinations
- **Networking cluster** (inserted after the cloud providers): 🌐 Networking · 🕸️ Istio · 🔗 K8s Net
- **DevSecOps** joins the security cluster: 🔐 Security · 🛡️ DevSecOps

## Notes
- Template-only change to `docs/overrides/main.html`; reuses the existing `.nb-quicknav` pill styling — no CSS change, no cache-bust bump, no page regeneration. V2-only.
- All target pages verified (`/networking/`, `/istio/`, `/kubernetes-networking/`, `/devsecops/`); `mkdocs build -f v2-mkdocs.yml` passes with all 25 links rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)