### PR TITLE
feat(v2/nav): hybrid quick-nav — direct pills + Popover category menus

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -6,47 +6,76 @@
 
 {#-
   Quick-nav bar rendered below the header on every page (via the `tabs` block,
-  which is empty here since navigation.tabs is disabled). Gives the key
-  cross-cutting destinations a persistent, one-click home as centered pill
-  chips — without collapsing the full left navigation tree.
+  which is empty here since navigation.tabs is disabled). Single slim row that
+  stays one row no matter how many destinations are added: the most-used
+  flagships are direct one-click pills, and the long-tail clusters collapse into
+  category menus built with the native HTML Popover API + CSS Anchor Positioning
+  (Baseline 2026) — zero JS, with free Esc/click-outside dismissal and focus
+  management. Adding a leaf grows a menu, never the bar.
 
-  Destinations are ordered into related category clusters and use short labels
-  (even when the underlying page title is long):
-    discovery (Topic Map · Digest · Videos) → platform (Kubernetes · Docker)
-    → delivery (GitOps · CI/CD) → IaC (Terraform · Ansible)
-    → cloud (AWS · Azure · GCP) → networking (Networking · Istio · K8s Net)
-    → security (Security · DevSecOps) → ops (Observability · SRE · DevOps)
-    → data (Messaging) → AI/ML (AI & MCP · MLOps) → Methodology,
-  with V1 Archive muted last.
+  Direct pills: Topic Map · Digest · Kubernetes · Docker · GitOps · Terraform · AI & MCP
+  Menus: Cloud (AWS · Azure · GCP) · Network (Networking · Istio · K8s Net)
+         · Security (Security · DevSecOps) · Ops (CI/CD · Observability · SRE · DevOps)
+         · More (Videos · Ansible · Messaging · MLOps · Methodology · V1 Archive)
 -#}
 {% block tabs %}
 <nav class="nb-quicknav" aria-label="Quick navigation">
   <div class="nb-quicknav__inner">
     <a class="nb-quicknav__link" href="/topic-map/">🗺️ Topic Map</a>
     <a class="nb-quicknav__link" href="/tech-digest/">📊 Digest</a>
-    <a class="nb-quicknav__link" href="/videos/">🎥 Videos</a>
     <a class="nb-quicknav__link" href="/kubernetes/">☸️ Kubernetes</a>
     <a class="nb-quicknav__link" href="/docker/">🐳 Docker</a>
     <a class="nb-quicknav__link" href="/gitops/">🔄 GitOps</a>
-    <a class="nb-quicknav__link" href="/cicd/">🚀 CI/CD</a>
     <a class="nb-quicknav__link" href="/terraform/">🏗️ Terraform</a>
-    <a class="nb-quicknav__link" href="/ansible/">📋 Ansible</a>
-    <a class="nb-quicknav__link" href="/aws/">☁️ AWS</a>
-    <a class="nb-quicknav__link" href="/azure/">☁️ Azure</a>
-    <a class="nb-quicknav__link" href="/GoogleCloudPlatform/">☁️ GCP</a>
-    <a class="nb-quicknav__link" href="/networking/">🌐 Networking</a>
-    <a class="nb-quicknav__link" href="/istio/">🕸️ Istio</a>
-    <a class="nb-quicknav__link" href="/kubernetes-networking/">🔗 K8s Net</a>
-    <a class="nb-quicknav__link" href="/kubernetes-security/">🔐 Security</a>
-    <a class="nb-quicknav__link" href="/devsecops/">🛡️ DevSecOps</a>
-    <a class="nb-quicknav__link" href="/monitoring/">📈 Observability</a>
-    <a class="nb-quicknav__link" href="/sre/">🛠️ SRE</a>
-    <a class="nb-quicknav__link" href="/devops/">♾️ DevOps</a>
-    <a class="nb-quicknav__link" href="/message-queue/">📨 Messaging</a>
     <a class="nb-quicknav__link" href="/ai-agents-mcp/">🤖 AI &amp; MCP</a>
-    <a class="nb-quicknav__link" href="/mlops/">🧠 MLOps</a>
-    <a class="nb-quicknav__link" href="/methodology/">📐 Methodology</a>
-    <a class="nb-quicknav__link nb-quicknav__link--muted" href="/v1/">📚 V1 Archive</a>
+
+    <span class="nb-quicknav__group">
+      <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-cloud" type="button">☁️ Cloud <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
+      <div class="nb-quicknav__menu" id="nb-pop-cloud" popover>
+        <a href="/aws/">☁️ AWS</a>
+        <a href="/azure/">☁️ Azure</a>
+        <a href="/GoogleCloudPlatform/">☁️ GCP</a>
+      </div>
+    </span>
+
+    <span class="nb-quicknav__group">
+      <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-net" type="button">🌐 Network <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
+      <div class="nb-quicknav__menu" id="nb-pop-net" popover>
+        <a href="/networking/">🌐 Networking</a>
+        <a href="/istio/">🕸️ Istio</a>
+        <a href="/kubernetes-networking/">🔗 K8s Net</a>
+      </div>
+    </span>
+
+    <span class="nb-quicknav__group">
+      <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-sec" type="button">🔐 Security <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
+      <div class="nb-quicknav__menu" id="nb-pop-sec" popover>
+        <a href="/kubernetes-security/">🔐 K8s Security</a>
+        <a href="/devsecops/">🛡️ DevSecOps</a>
+      </div>
+    </span>
+
+    <span class="nb-quicknav__group">
+      <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-ops" type="button">⚙️ Ops <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
+      <div class="nb-quicknav__menu" id="nb-pop-ops" popover>
+        <a href="/cicd/">🚀 CI/CD</a>
+        <a href="/monitoring/">📈 Observability</a>
+        <a href="/sre/">🛠️ SRE</a>
+        <a href="/devops/">♾️ DevOps</a>
+      </div>
+    </span>
+
+    <span class="nb-quicknav__group">
+      <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-more" type="button">⋯ More <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
+      <div class="nb-quicknav__menu" id="nb-pop-more" popover>
+        <a href="/videos/">🎥 Videos</a>
+        <a href="/ansible/">📋 Ansible</a>
+        <a href="/message-queue/">📨 Messaging</a>
+        <a href="/mlops/">🧠 MLOps</a>
+        <a href="/methodology/">📐 Methodology</a>
+        <a class="nb-quicknav__menu-muted" href="/v1/">📚 V1 Archive</a>
+      </div>
+    </span>
   </div>
 </nav>
 {% endblock %}

--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1287,8 +1287,91 @@ input[type="text"] {
 .nb-quicknav__link--muted:hover {
   opacity: 1;
 }
+
+/* ── Category menus: native Popover API + CSS Anchor Positioning (Baseline 2026)
+   The long-tail clusters collapse behind category buttons so the bar stays one
+   row. Opening is click-driven via the Popover API (free Esc / click-outside
+   dismissal + focus management); zero JS. ── */
+.nb-quicknav__group {
+  display: inline-flex;
+}
+/* thin divider between the direct pills and the category menus */
+.nb-quicknav__group:first-of-type {
+  margin-inline-start: 0.3rem;
+  padding-inline-start: 0.55rem;
+  border-inline-start: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 18%, transparent);
+}
+.nb-quicknav__btn {
+  font-family: inherit;
+  cursor: pointer;
+}
+.nb-quicknav__caret {
+  font-size: 0.85em;
+  opacity: 0.75;
+  transition: transform 0.18s ease;
+}
+.nb-quicknav__group:has(.nb-quicknav__menu:popover-open) .nb-quicknav__caret {
+  transform: rotate(180deg);
+}
+.nb-quicknav__menu {
+  inset: auto; /* reset the UA-centered popover defaults */
+  margin: 0;
+  position-area: bottom span-inline-end; /* drop below the invoking button */
+  position-try-fallbacks: flip-block, flip-inline; /* auto-flip near edges */
+  margin-block-start: 0.45rem;
+  min-width: 9.5rem;
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  border: 1px solid color-mix(in srgb, var(--md-accent-fg-color) 30%, transparent);
+  border-radius: 0.6rem;
+  background: color-mix(in srgb, var(--md-header-bg-color) 86%, #000);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+  /* entry/exit animation across the display toggle */
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.16s ease, transform 0.16s ease,
+              overlay 0.16s allow-discrete, display 0.16s allow-discrete;
+}
+.nb-quicknav__menu:popover-open {
+  opacity: 1;
+  transform: translateY(0);
+}
+@starting-style {
+  .nb-quicknav__menu:popover-open {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+.nb-quicknav__menu a {
+  display: block;
+  padding: 0.34rem 0.6rem;
+  border-radius: 0.4rem;
+  color: rgba(255, 255, 255, 0.86);
+  text-decoration: none;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: background 0.14s ease, color 0.14s ease;
+}
+.nb-quicknav__menu a:hover,
+.nb-quicknav__menu a:focus-visible {
+  background: color-mix(in srgb, var(--md-accent-fg-color) 30%, transparent);
+  color: #fff;
+  outline: none;
+}
+.nb-quicknav__menu-muted {
+  opacity: 0.62;
+  margin-block-start: 0.15rem;
+  padding-block-start: 0.42rem !important;
+  border-block-start: 1px solid rgba(255, 255, 255, 0.1);
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .nb-quicknav__link { transition: none; }
+  .nb-quicknav__link,
+  .nb-quicknav__caret,
+  .nb-quicknav__menu { transition: none; }
   .nb-quicknav__link:hover { transform: none; }
 }
 /* On phones the left drawer already exposes navigation; one scrollable row. */

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -114,7 +114,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.29
+  - static/v2_elite.css?v=2.9.31
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.19


### PR DESCRIPTION
## Summary

Collapses the 25-destination quick-nav from **3 wrapped rows to a single slim row** that stays one row regardless of how many destinations are added.

### Structure
- **7 direct one-click pills** (most-used flagships): 🗺️ Topic Map · 📊 Digest · ☸️ Kubernetes · 🐳 Docker · 🔄 GitOps · 🏗️ Terraform · 🤖 AI & MCP
- **5 category menus** for the long tail — native **HTML Popover API + CSS Anchor Positioning** (Baseline 2026), zero JS:
  - ☁️ **Cloud** → AWS · Azure · GCP
  - 🌐 **Network** → Networking · Istio · K8s Net
  - 🔐 **Security** → K8s Security · DevSecOps
  - ⚙️ **Ops** → CI/CD · Observability · SRE · DevOps
  - ⋯ **More** → Videos · Ansible · Messaging · MLOps · Methodology · V1 Archive

### Why
Keeps the hot paths at one click (the portal's whole value) while the rarely-used clusters fold away, so the bar never grows past one row. Popover API gives free Esc / click-outside dismissal and focus management, identical on touch and desktop; menus drop below their button via `position-area` with flip fallbacks, animate in via `@starting-style`, and rotate the caret with `:has()`. `prefers-reduced-motion` honored.

### Notes
- All 25 destinations preserved. Cache-bust `?v=2.9.31`. V2-only, no page regeneration.
- `mkdocs build -f v2-mkdocs.yml` passes; 7 pills + 5 popover buttons + 5 popover panels render on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)