### PR TITLE
feat(v2/gen): add Kubernetes provider hub (sub-page index)

### DIFF
--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -97,6 +97,25 @@ class V2VisionEngine:
                 ("aws-backup", "Backup"),
                 ("aws-newfeatures", "New Features"),
             ],
+            # Kubernetes is well-classified (rich parent + substantial distinct
+            # children), so nothing is merged here — the hub is purely an index
+            # so the flagship landing surfaces its deep-dive topic pages.
+            "kubernetes": [
+                ("kubernetes-tools", "Tools"),
+                ("kubernetes-networking", "Networking"),
+                ("kubernetes-security", "Security"),
+                ("kubernetes-monitoring", "Monitoring"),
+                ("kubernetes-storage", "Storage"),
+                ("kubernetes-autoscaling", "Autoscaling"),
+                ("kubernetes-operators-controllers", "Operators"),
+                ("kubernetes-alternatives", "Alternatives"),
+                ("kubernetes-bigdata", "Big Data"),
+                ("kubernetes-tutorials", "Tutorials"),
+                ("kubernetes-backup-migrations", "Backup & Migrations"),
+                ("kubernetes-client-libraries", "Client Libraries"),
+                ("kubernetes-based-devel", "Local Dev"),
+                ("kubernetes-on-premise", "On-Premise"),
+            ],
         }
         
         self.library_criteria = (


### PR DESCRIPTION
Audit of fragmentation found only two prefix clusters: `aws` (fixed in v2.9.34) and `kubernetes`. Unlike AWS, **kubernetes is well-classified** — rich parent (157 links) + substantial distinct children — so **nothing is merged**. This only adds a *Deep-Dive Topic Pages* hub to `kubernetes.md` indexing its 14 substantial sub-pages. Other small pages are legitimate distinct topics, left alone. Verified with `--render-only`; generator-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)