### PR TITLE
fix(v2/nav): make tall Kubernetes menu reliable (2 cols, no scroll, no flip-block)

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -36,7 +36,7 @@
 
     <span class="nb-quicknav__group">
       <button class="nb-quicknav__link nb-quicknav__btn" popovertarget="nb-pop-k8s" type="button">☸️ Kubernetes <span class="nb-quicknav__caret" aria-hidden="true">▾</span></button>
-      <div class="nb-quicknav__menu" id="nb-pop-k8s" popover>
+      <div class="nb-quicknav__menu nb-quicknav__menu--cols" id="nb-pop-k8s" popover>
         <a href="/kubernetes/">☸️ Overview</a>
         <a href="/docker/">🐳 Docker</a>
         <a href="/kubernetes-tools/">🧰 Tools</a>

--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1351,7 +1351,9 @@ input[type="text"] {
      be all-physical or all-logical — mixing (e.g. `bottom span-inline-end`) is
      invalid and silently computes to `none`, leaving the menu over the button. */
   position-area: bottom span-right;
-  position-try-fallbacks: flip-block, flip-inline; /* auto-flip near edges */
+  /* Only flip horizontally near the right edge. NEVER flip-block: the quick-nav
+     is a sticky top bar, so a tall menu flipped above would shoot off-screen. */
+  position-try-fallbacks: flip-inline;
   margin-block-start: 0.45rem;
   min-width: 9.5rem;
   padding: 0.35rem;
@@ -1400,6 +1402,19 @@ input[type="text"] {
   margin-block-start: 0.15rem;
   padding-block-start: 0.42rem !important;
   border-block-start: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* Two-column layout for long menus (e.g. Kubernetes, 22 items) so they stay
+   short enough to show in full WITHOUT a scrollbar — the scrollable tall popover
+   was unreliable. Multicol is column-major, so reading order is preserved. */
+.nb-quicknav__menu--cols {
+  display: block;
+  column-count: 2;
+  column-gap: 0.4rem;
+  min-width: 22rem;
+}
+.nb-quicknav__menu--cols a {
+  break-inside: avoid;
 }
 
 /* ── Nested submenu (e.g. Cloud → AWS ▸ → AWS pages) ──

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -114,7 +114,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.36
+  - static/v2_elite.css?v=2.9.37
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.19


### PR DESCRIPTION
The Kubernetes dropdown (22 items) was the only menu tall enough to need a scrollbar on an anchor-positioned popover, making it open/behave unreliably vs the others. Fix: 2-column layout (~731px → ~353px, no scrollbar) + removed flip-block (sticky top bar must never flip a tall menu off-screen-top). Verified in Chrome 148 (Playwright) at viewport heights 700–1080. Cache-bust ?v=2.9.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)