### PR TITLE
feat: V2 portal UX — label heatmap, Topic Map nav group, Videos promotion, video TOC cleanup

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -177,6 +177,62 @@ html {
 }
 
 /* ---------------------------------------------------- */
+/* LABEL HEATMAP (Confluence-style popular-labels cloud) */
+/* ---------------------------------------------------- */
+
+.v2-tag-heatmap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.7rem;
+  align-items: baseline;
+  padding: 1.1rem 1.2rem;
+  margin: 1rem 0 1.75rem;
+  border: 1px solid rgba(38, 50, 56, 0.12);
+  border-radius: 10px;
+  background: rgba(38, 50, 56, 0.04);
+}
+
+[data-md-color-scheme="slate"] .v2-tag-heatmap {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.v2-heat-tag {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.2em;
+  line-height: 1.1;
+  font-weight: 600;
+  text-decoration: none;
+  color: #455a64;
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.v2-heat-tag:hover {
+  transform: translateY(-1px);
+  color: var(--md-accent-fg-color);
+}
+
+.v2-heat-n {
+  font-size: 0.6em;
+  font-weight: 700;
+  opacity: 0.55;
+  vertical-align: super;
+}
+
+/* Size + warmth ramp: level 1 = least used, level 6 = most used. */
+.v2-heat-1 { font-size: 0.8rem;  opacity: 0.7; }
+.v2-heat-2 { font-size: 0.95rem; }
+.v2-heat-3 { font-size: 1.15rem; }
+.v2-heat-4 { font-size: 1.45rem; }
+.v2-heat-5 { font-size: 1.8rem;  color: #ef6c00; }
+.v2-heat-6 { font-size: 2.25rem; color: #d84315; font-weight: 700; }
+
+[data-md-color-scheme="slate"] .v2-heat-tag { color: #b0bec5; }
+[data-md-color-scheme="slate"] .v2-heat-5 { color: #ffb74d; }
+[data-md-color-scheme="slate"] .v2-heat-6 { color: #ff8a65; }
+
+/* ---------------------------------------------------- */
 /* MICRO-ANIMATIONS & HOVER STATES                      */
 /* ---------------------------------------------------- */
 

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import math
 import hashlib
 import asyncio
 import yaml
@@ -1636,6 +1637,40 @@ class V2VisionEngine:
             [t for t in sorted_tags if t not in standard_order and not t.endswith("CONTENT]")],
             key=lambda t: -tag_meta[t]["count"],
         )
+
+        # Label Heatmap (Confluence-style "popular labels" cloud): every label is
+        # listed alphabetically and sized/coloured by how many resources carry it,
+        # so the most-used tags read biggest/warmest. Clicking jumps to the section.
+        # Sizing uses a LOG scale because counts span ~1..2800; a linear scale would
+        # collapse everything except the few giant maturity tags into the smallest
+        # bucket. Six levels map onto the .v2-heat-1..6 CSS ramp.
+        _heat_counts = [tag_meta[t]["count"] for t in sorted_tags]
+        if _heat_counts:
+            _cmin, _cmax = min(_heat_counts), max(_heat_counts)
+            _lmin, _lmax = math.log(_cmin), math.log(_cmax)
+
+            def _heat_level(count):
+                if _lmax == _lmin:
+                    return 3
+                frac = (math.log(count) - _lmin) / (_lmax - _lmin)
+                return 1 + round(frac * 5)  # 1..6
+
+            md += "## Label Heatmap\n\n"
+            md += (
+                "Bigger, warmer labels cover more resources. "
+                "Click any label to jump to its section below.\n\n"
+            )
+            md += '<div class="v2-tag-heatmap">\n'
+            for t in sorted(sorted_tags, key=lambda x: tag_meta[x]["display"].lower()):
+                m = tag_meta[t]
+                disp = m["display"].replace(" Content", "")
+                lvl = _heat_level(m["count"])
+                md += (
+                    f'<a class="v2-heat-tag v2-heat-{lvl}" href="#{m["slug"]}" '
+                    f'title="{m["count"]} resources">{disp}'
+                    f'<span class="v2-heat-n">{m["count"]}</span></a>\n'
+                )
+            md += "</div>\n\n"
 
         # Build a grouped TOC: maturity as a clean numbered list; domains and the
         # language/format tail as compact, count-sorted inline pill rows.

--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1741,18 +1741,24 @@ class V2VisionEngine:
                 "nav:",
                 "  - \"🔙 Back to V1 (Exhaustive)\": https://nubenetes.com/v1/",
                 "  - \"The 2026 Vision\": index.md",
-                "  - \"Topic Map\": topic-map.md",
-                "  - \"Methodology\": methodology.md",
-                "  - \"Technical Tags\": tags.md",
+                # Topic Map is a collapsible hub for the three site-orientation
+                # pages (the map itself + how it's built + the tag index), with
+                # topic-map.md as its section index (navigation.indexes).
+                "  - \"Topic Map\":",
+                "    - topic-map.md",
+                "    - \"Methodology\": methodology.md",
+                "    - \"Technical Tags\": tags.md",
+                # Videos: prominent top-level dropdown, kept high in the nav with
+                # its category subpages as children.
+                "  - \"Agentic Video Hub\":",
+                "    - videos/index.md",
+                "    - \"AI Agents and MCP\": videos/ai-agents.md",
+                "    - \"DevOps, IaC, and SRE\": videos/devops-iac.md",
+                "    - \"Cloud Native Core\": videos/cloud-native.md",
+                "    - \"Fundamentals\": videos/fundamentals.md",
                 "  - \"Intelligence Digest\":",
                 "    - \"Tech & Cloud Digest\": tech-digest.md",
-                "    - \"Industry & Geo Digest\": industry-digest.md",
-                "  - \"Agentic Video Hub\":",
-                "      - videos/index.md",
-                "      - \"AI Agents and MCP\": videos/ai-agents.md",
-                "      - \"DevOps, IaC, and SRE\": videos/devops-iac.md",
-                "      - \"Cloud Native Core\": videos/cloud-native.md",
-                "      - \"Fundamentals\": videos/fundamentals.md"
+                "    - \"Industry & Geo Digest\": industry-digest.md"
             ]
 
             dim_groups = {}

--- a/src/v2_video_portal.py
+++ b/src/v2_video_portal.py
@@ -181,24 +181,18 @@ def generate_v2_videos():
             "    You are browsing the AI-Curated V2 Elite Edition. Looking for the exhaustive list of references? Check out the [**V1 Historical Archive**](/v1/).",
             "",
             f"Welcome to the **{theme_title}** section of the V2 Video Hub. Explore curated high-density videos with architectural summaries.",
-            "",
-            "## Table of Contents",
             ""
         ]
 
-        # Group by Technology for TOC
+        # In-page Markdown Table of Contents intentionally omitted: it duplicates
+        # Material's native right-column "On this page" TOC (toc.follow). We still
+        # build the ordered technology list below because it drives the rendering
+        # order of the grouped video sections.
         techs = []
         for v in videos:
             tech = v.get("technology", "Cloud Native")
             if tech not in techs:
                 techs.append(tech)
-
-        for idx, tech in enumerate(techs, 1):
-            clean_tech = clean_header(tech)
-            slug = get_slug(tech)
-            content.append(f"{idx}. [{clean_tech}](#{slug})")
-
-        content.append("")
 
         # Render Grouped Videos
         grouped_by_tech = {}

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -114,7 +114,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.38
+  - static/v2_elite.css?v=2.9.39
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.19

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -154,15 +154,16 @@ markdown_extensions:
 nav:
   - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/v1/
   - "The 2026 Vision": index.md
-  - "Topic Map": topic-map.md
-  - "Methodology": methodology.md
-  - "Technical Tags": tags.md
+  - "Topic Map":
+    - topic-map.md
+    - "Methodology": methodology.md
+    - "Technical Tags": tags.md
   - "Agentic Video Hub":
-      - videos/index.md
-      - "AI Agents and MCP": videos/ai-agents.md
-      - "DevOps, IaC, and SRE": videos/devops-iac.md
-      - "Cloud Native Core": videos/cloud-native.md
-      - "Fundamentals": videos/fundamentals.md
+    - videos/index.md
+    - "AI Agents and MCP": videos/ai-agents.md
+    - "DevOps, IaC, and SRE": videos/devops-iac.md
+    - "Cloud Native Core": videos/cloud-native.md
+    - "Fundamentals": videos/fundamentals.md
   - "Intelligence Digest":
     - "Tech & Cloud Digest": tech-digest.md
     - "Industry & Geo Digest": industry-digest.md


### PR DESCRIPTION
Three related V2-portal UX improvements. All generator-owned: regenerated `v2-docs/*.md` is **not** committed (CI republishes); PR is source-only.

## 1. Confluence-style label heatmap (Technical Tags page)
A weighted "popular labels" cloud at the top of `tags.md`: every label listed alphabetically, **sized + colour-warmed by resource count** (log scale, 6 levels). Most-used = biggest/hottest (`Community-Tool` 1764 → largest). Clicking jumps to that label's section.
- `v2_optimizer._generate_global_tag_index` emits `.v2-tag-heatmap`
- `docs/static/v2_elite.css` `.v2-heat-1..6` ramp (light + slate)
- CSS cache-buster → `v2.9.39`

## 2. Topic Map nav grouping
`Topic Map`, `Methodology`, `Technical Tags` are all about how the portal is structured, so they're now folded into one collapsible **Topic Map** hub (with `topic-map.md` as the section index via `navigation.indexes`).

## 3. Videos promoted
`Agentic Video Hub` moved above `Intelligence Digest` as a prominent top-level dropdown, keeping its category subpages.

> Note: `navigation.tabs` stays disabled (≈16 top-level sections still overflow the tab bar); these render as left-sidebar collapsible buttons.

## 4. Redundant video TOC removed
The video category pages had an in-page `## Table of Contents` that duplicated Material's native right-column "On this page" TOC (`toc.follow`) — now dropped, matching how the topic pages already omit it. Section render order is preserved.

## Verification
- `mkdocs build -f v2-mkdocs.yml` succeeds (exit 0).
- Heatmap: 75 anchors, all resolve (0 dangling); log levels distribute 1×L6 … 44×L1.
- Nav builds with the grouped Topic Map + promoted Videos.
- Regenerated video pages confirmed free of the manual TOC, 18 H2 sections retained for the right-column TOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)