### PR TITLE
revert: disable top nav tabs; group orientation pages under "Portal Guide"

### DIFF
--- a/src/v2_optimizer.py
+++ b/src/v2_optimizer.py
@@ -1784,13 +1784,15 @@ class V2VisionEngine:
                 "nav:",
                 "  - \"🔙 Back to V1 (Exhaustive)\": https://nubenetes.com/v1/",
                 "  - \"The 2026 Vision\": index.md",
-                # Topic Map is a collapsible hub for the three site-orientation
-                # pages (the map itself + how it's built + the tag index), with
-                # topic-map.md as its section index (navigation.indexes).
-                "  - \"Topic Map\":",
-                "    - topic-map.md",
+                # Portal Guide: collapsible hub for the site-orientation / meta
+                # pages — the topic directory, how the portal is curated, the tag
+                # index and the project About. about.md is pulled out of its
+                # Architectural Foundations dimension here (see _FIXED_PAGES below).
+                "  - \"Portal Guide\":",
+                "    - \"Topic Map\": topic-map.md",
                 "    - \"Methodology\": methodology.md",
                 "    - \"Technical Tags\": tags.md",
+                "    - \"About\": about.md",
                 # Videos: prominent top-level dropdown, kept high in the nav with
                 # its category subpages as children.
                 "  - \"Agentic Video Hub\":",
@@ -1804,14 +1806,21 @@ class V2VisionEngine:
                 "    - \"Industry & Geo Digest\": industry-digest.md"
             ]
 
+            # Topic pages promoted into a fixed header group above; skip them in
+            # the dimension loop so they are not also listed under their dimension.
+            _FIXED_PAGES = {"about.md"}
+
             dim_groups = {}
             for f_name, info in data.items():
                 dim_groups.setdefault(info["dim"], []).append(f_name)
 
             for dim in self.dimensions.keys():
                 if dim in dim_groups:
+                    dim_files = [f for f in sorted(dim_groups[dim]) if f not in _FIXED_PAGES]
+                    if not dim_files:
+                        continue
                     dim_nav = [f"  - \"{dim}\":"]
-                    for f in sorted(dim_groups[dim]):
+                    for f in dim_files:
                         dim_nav.append(f"    - \"{data[f]['title']}\": {f}")
                     nav.extend(dim_nav)
 

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -29,12 +29,10 @@ theme:
         icon: material/shield-moon-outline
         name: Switch to dark mode
   features:
-    # navigation.tabs: top-level sections render as a top tab bar AND the left
-    # sidebar stays, scoped to the active tab. With ~16 top-level sections the
-    # bar can overflow on narrow viewports; Material handles that with a
-    # horizontal scroll, and .sticky keeps the bar pinned while scrolling.
-    - navigation.tabs
-    - navigation.tabs.sticky
+    # navigation.tabs / .sticky disabled: a top tab bar forces Material to scope
+    # the left sidebar to the active tab only, which breaks the always-populated
+    # vertical list we want. The left sidebar handles all sections as a standard
+    # collapsible list and stays populated on every page incl. home.
     - navigation.top
     - navigation.tracking
     # navigation.sections disabled: render top-level as COLLAPSIBLE nested
@@ -157,10 +155,11 @@ markdown_extensions:
 nav:
   - "🔙 Back to V1 (Exhaustive)": https://nubenetes.com/v1/
   - "The 2026 Vision": index.md
-  - "Topic Map":
-    - topic-map.md
+  - "Portal Guide":
+    - "Topic Map": topic-map.md
     - "Methodology": methodology.md
     - "Technical Tags": tags.md
+    - "About": about.md
   - "Agentic Video Hub":
     - videos/index.md
     - "AI Agents and MCP": videos/ai-agents.md
@@ -176,7 +175,6 @@ nav:
     - "ChatGPT": chatgpt.md
     - "MLOps": mlops.md
   - "Architectural Foundations":
-    - "About": about.md
     - "Cheatsheets": cheatsheets.md
     - "Cloud Arch Diagrams": cloud-arch-diagrams.md
     - "Cloud Asset Inventory": cloud-asset-inventory.md


### PR DESCRIPTION
Reverts the `navigation.tabs` change from #436 (the top tab bar forced Material to scope the left sidebar to the active tab, regressing the always-populated vertical nav) and applies the intended grouping in the restored left nav instead.

## Changes
- **Revert top tabs**: remove `navigation.tabs` + `.tabs.sticky` → left column behaves as before (all sections, populated on every page).
- **New "Portal Guide" group** (collapsible, left nav): Topic Map · Methodology · Technical Tags · About.
- **About** pulled out of its Architectural Foundations dimension (skipped in the generator's dimension loop) so it is not listed twice.
- **Agentic Video Hub** stays a prominent top-level group with its video subpages — no longer at risk of falling into a tab-overflow "...more" menu.

Both the committed `v2-mkdocs.yml` nav and the generator (`_sync_enterprise_navigation`) are updated so a future regen stays consistent.

## Verification
`mkdocs build -f v2-mkdocs.yml` (exit 0): 0 top tabs; "About" appears exactly once; Portal Guide children = [Topic Map, Methodology, Technical Tags, About]; Agentic Video Hub children = the 4 video category pages.

> Group name "Portal Guide" is a placeholder for the orientation/meta pages — trivially renameable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)