### PR TITLE
fix: anchor the new Portal Guide & Videos header dropdowns

### DIFF
--- a/docs/static/v2_elite.css
+++ b/docs/static/v2_elite.css
@@ -1372,8 +1372,12 @@ input[type="text"] {
 /* Explicit anchor pairing per button↔menu — do NOT rely on the popover's
    implicit anchor (it isn't established reliably, leaving the menu in its
    static position over the button). */
+[popovertarget="nb-pop-guide"]    { anchor-name: --nb-a-guide; }
+#nb-pop-guide    { position-anchor: --nb-a-guide; }
 [popovertarget="nb-pop-digest"]   { anchor-name: --nb-a-digest; }
 #nb-pop-digest   { position-anchor: --nb-a-digest; }
+[popovertarget="nb-pop-videos"]   { anchor-name: --nb-a-videos; }
+#nb-pop-videos   { position-anchor: --nb-a-videos; }
 [popovertarget="nb-pop-k8s"]      { anchor-name: --nb-a-k8s; }
 #nb-pop-k8s      { position-anchor: --nb-a-k8s; }
 [popovertarget="nb-pop-delivery"] { anchor-name: --nb-a-delivery; }

--- a/v2-mkdocs.yml
+++ b/v2-mkdocs.yml
@@ -115,7 +115,7 @@ extra:
 extra_css:
   - https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap
   - static/extra.css
-  - static/v2_elite.css?v=2.9.39
+  - static/v2_elite.css?v=2.9.42
 
 extra_javascript:
   - static/v2_filter.js?v=2.9.19


### PR DESCRIPTION
The `nb-quicknav` header popovers are positioned with explicit CSS anchor-positioning pairs (`anchor-name` on the button + `position-anchor` on the menu), keyed per popover id. The two new menus added in #439 (`nb-pop-guide`, `nb-pop-videos`) had **no** such pairs, so their popovers opened **unanchored** → wrong position / "broken".

## Fix
- Add `anchor-name` / `position-anchor` pairs for `nb-pop-guide` and `nb-pop-videos` (same pattern as the 11 working dropdowns).
- Bump CSS cache-buster → `2.9.42`.

Verified: built CSS contains both new anchor pairs; build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)